### PR TITLE
macros for action return type and fsm pointer type defined in header

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -280,6 +280,11 @@ char* commonHeaderStart(pCMachineData pcmw, pMACHINE_INFO pmi, char *arrayName)
            , cp
           );
 
+   fprintf(pcmw->hFile
+           , "#undef ACTION_RETURN_TYPE\n#define ACTION_RETURN_TYPE %s_EVENT\n"
+           , cp
+          );
+
    fprintf(pcmw->hFile, "#ifdef %s_DEBUG\n", cp);
    fprintf(pcmw->hFile, "extern char *%s_EVENT_NAMES[];\n", cp);
    fprintf(pcmw->hFile, "#endif\n\n");
@@ -346,6 +351,11 @@ char* commonHeaderStart(pCMachineData pcmw, pMACHINE_INFO pmi, char *arrayName)
            pmi->name->name,
            cp,
            cp);
+
+   fprintf(pcmw->hFile
+           , "#undef FSM_TYPE_PTR\n#define FSM_TYPE_PTR p%s\n"
+           , cp
+          );
 
    if (generate_instance)
    {
@@ -1877,6 +1887,11 @@ char* subMachineHeaderStart(pCMachineData pcmw, pMACHINE_INFO pmi, char *arrayNa
            pmi->name->name,
            cp,
            cp);
+
+   fprintf(pcmw->hFile
+           , "#undef FSM_TYPE_PTR\n#define FSM_TYPE_PTR p%s\n"
+           , cp
+          );
 
    if (generate_instance)
    {

--- a/test/full_test37/Makefile
+++ b/test/full_test37/Makefile
@@ -1,0 +1,31 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -DFSM_DEBUG \
+         -DSUB_MACHINE1_DEBUG \
+         -DSUB_MACHINE2_DEBUG \
+         -DSUB_MACHINE3_DEBUG \
+         -DTOP_LEVEL_DEBUG \
+         -I../ \
+	 -Wall \
+	 -ggdb
+
+FSM_FLAGS = -ts
+
+FSM_SRC = $(shell find . -name "*.fsm" -printf "%P ")
+
+GENERATED_SRC = \
+	sub_machine1.c \
+	sub_machine2.c \
+	sub_machine3.c
+
+SRC = $(shell find . -name "*-actions.c" -printf "%P ")
+
+include ../test.mk
+
+include ../../fsmrules.mk
+
+

--- a/test/full_test37/fsmlang.css
+++ b/test/full_test37/fsmlang.css
@@ -1,0 +1,84 @@
+.machine {
+	border-collapse: collapse;
+	border-style: solid;
+	border-width: .5px;
+	border-color: black;
+}
+
+.machine td, .machine th {
+	border-style: solid;
+	border-width: .5px;
+	border-color: black;
+	padding: 10px;
+}
+
+.eventLabel, .stateLabel, .blankCorner {
+	background-color: rgb(96,182,255);
+	padding: 10px;
+}
+
+.eventName, .stateName {
+	background-color: rgb(96,182,255);
+	border-style: solid;
+	border-width: .5px;
+	border-color: black;
+}
+
+
+.action {
+	color: green;
+}
+
+.nullAction {
+	color: orange;
+}
+
+.noAction {
+	color: green;
+}
+
+.elements {
+	margin: 10px;
+	border-style: solid;
+	border-collapse: collapse;
+	border-width: .5px;
+	border-color: black;
+	width: 75%;
+}
+
+.elements th {
+	background-color: rgb(96,182,255);
+	border-style: solid;
+	border-width: .5px;
+	border-color: black;
+	padding: 3px;
+}
+
+.elements td {
+	border-style: solid;
+	border-width: .5px;
+	border-color: black;
+	padding: 3px;
+}
+
+.label {
+	font-weight: bold;
+	padding: 3px;
+}
+
+.action .return_decl {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.action .return_decl li {
+  margin-top: 0px;
+}
+
+.action ul + br {
+	content: "";
+	margin: 0px;
+	display: block;
+	font-size: 0px;
+}
+

--- a/test/full_test37/sm1-actions.c
+++ b/test/full_test37/sm1-actions.c
@@ -1,0 +1,59 @@
+#include <string.h>
+
+#include "sub_machine1.h"
+
+ACTION_RETURN_TYPE THIS(a3)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return PARENT(e3);
+}
+
+ACTION_RETURN_TYPE THIS(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(e3);
+}
+
+ACTION_RETURN_TYPE THIS(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(e2);
+}
+
+ACTION_RETURN_TYPE THIS(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(noEvent);
+}
+
+SUB_MACHINE1_STATE THIS(checkTransition)(FSM_TYPE_PTR pfsm, ACTION_RETURN_TYPE e)
+{
+	DBG_PRINTF(__func__);
+
+   (void) pfsm;
+   (void) e;
+
+   return sub_machine1_s3;
+}
+
+void THIS(translate_e7_data)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF(__func__);
+
+	psub_machine1->data.field1 = pfsm->data.field1;
+	memcpy(psub_machine1->data.field2,pfsm->data.field2, sizeof(psub_machine1->data.field2));
+
+	DBG_PRINTF("The int: %d\n", psub_machine1->data.field1);
+	DBG_PRINTF("The string: %s\n", psub_machine1->data.field2);
+}
+
+ACTION_RETURN_TYPE THIS(handle_e7)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test37/sm2-actions.c
+++ b/test/full_test37/sm2-actions.c
@@ -1,0 +1,30 @@
+#include "sub_machine2.h"
+
+ACTION_RETURN_TYPE THIS(a3)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return PARENT(e4);
+}
+
+ACTION_RETURN_TYPE THIS(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(e3);
+}
+
+ACTION_RETURN_TYPE THIS(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(e2);
+}
+
+ACTION_RETURN_TYPE THIS(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(noEvent);
+}
+

--- a/test/full_test37/sm3-actions.c
+++ b/test/full_test37/sm3-actions.c
@@ -1,0 +1,36 @@
+#include "sub_machine3.h"
+
+ACTION_RETURN_TYPE THIS(a3)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return PARENT(noEvent);
+}
+
+ACTION_RETURN_TYPE THIS(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(e3);
+}
+
+ACTION_RETURN_TYPE THIS(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(e2);
+}
+
+ACTION_RETURN_TYPE THIS(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+
+   return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE THIS(handle_e7)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test37/test.canonical
+++ b/test/full_test37/test.canonical
@@ -1,0 +1,90 @@
+event: top_level_e1; state: top_level_s1
+top_level_a1
+event: top_level_e2; state: top_level_s2
+top_level_activate_sub_machine1
+event: top_level_sub_machine1_e1; state: top_level_s2
+event: sub_machine1_e1; state: sub_machine1_s1
+weak: sub_machine1_a1
+event: top_level_e5; state: top_level_s2
+top_level_noAction
+
+0
+
+event: top_level_e5; state: top_level_s2
+top_level_noAction
+weak: top_level_handle_dispatch
+sub_machine1_noAction
+sub_machine2_noAction
+event: top_level_e7; state: top_level_s2
+weak: top_level_handle_other_passed_event
+weak: sub_machine1_translate_e7_data
+event: sub_machine1_e7; state: sub_machine1_s2
+weak: sub_machine1_handle_e7
+event: sub_machine3_e7; state: sub_machine3_s1
+weak: sub_machine3_handle_e7
+
+1
+
+event: top_level_e5; state: top_level_s2
+top_level_noAction
+weak: top_level_handle_dispatch
+sub_machine1_noAction
+sub_machine2_noAction
+event: top_level_e7; state: top_level_s2
+weak: top_level_handle_other_passed_event
+weak: sub_machine1_translate_e7_data
+event: sub_machine1_e7; state: sub_machine1_s2
+weak: sub_machine1_handle_e7
+event: sub_machine3_e7; state: sub_machine3_s1
+weak: sub_machine3_handle_e7
+
+2
+
+event: top_level_e5; state: top_level_s2
+top_level_noAction
+weak: top_level_handle_dispatch
+sub_machine1_noAction
+sub_machine2_noAction
+event: top_level_e7; state: top_level_s2
+weak: top_level_handle_other_passed_event
+weak: sub_machine1_translate_e7_data
+event: sub_machine1_e7; state: sub_machine1_s2
+weak: sub_machine1_handle_e7
+event: sub_machine3_e7; state: sub_machine3_s1
+weak: sub_machine3_handle_e7
+
+3
+
+event: top_level_e5; state: top_level_s2
+top_level_noAction
+weak: top_level_handle_dispatch
+sub_machine1_noAction
+sub_machine2_noAction
+event: top_level_e7; state: top_level_s2
+weak: top_level_handle_other_passed_event
+weak: sub_machine1_translate_e7_data
+event: sub_machine1_e7; state: sub_machine1_s2
+weak: sub_machine1_handle_e7
+event: sub_machine3_e7; state: sub_machine3_s1
+weak: sub_machine3_handle_e7
+
+4
+
+event: top_level_e5; state: top_level_s2
+top_level_noAction
+weak: top_level_handle_dispatch
+sub_machine1_noAction
+sub_machine2_noAction
+event: top_level_e7; state: top_level_s2
+weak: top_level_handle_other_passed_event
+weak: sub_machine1_translate_e7_data
+event: sub_machine1_e7; state: sub_machine1_s2
+weak: sub_machine1_handle_e7
+event: sub_machine3_e7; state: sub_machine3_s1
+weak: sub_machine3_handle_e7
+
+
+event: top_level_e8; state: top_level_s2
+top_level_noAction
+event: top_level_e5; state: top_level_s4
+top_level_noAction

--- a/test/full_test37/tl-actions.c
+++ b/test/full_test37/tl-actions.c
@@ -1,0 +1,53 @@
+#include <unistd.h>
+
+#include "top_level.h"
+
+ACTION_RETURN_TYPE THIS(activate_sub_machine1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return SUB_MACHINE1(e1);
+}
+
+ACTION_RETURN_TYPE THIS(activate_sub_machine2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return SUB_MACHINE2(e1);
+}
+
+ACTION_RETURN_TYPE THIS(activate_sub_machine3)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return SUB_MACHINE3(e1);
+}
+
+int main (int argc, char **argv)
+{
+   RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e1));
+   RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e2));
+   RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e5));
+
+   for (int i = 0; i < 5; i++)
+   {
+      DBG_PRINTF("\n%d\n"
+            , i
+            );
+      RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e5));
+      RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e6));
+      ptop_level->data.field1 = i;
+      snprintf(ptop_level->data.field2,sizeof(ptop_level->data.field2)-1, "loop: %.1d", i);
+      RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e7));
+   }
+
+	DBG_PRINTF("\n");
+   RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e8));
+   RUN_STATE_MACHINE(ptop_level, TOP_LEVEL(e5));
+
+   return 0;
+}
+
+ACTION_RETURN_TYPE THIS(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test37/top_level.fsm
+++ b/test/full_test37/top_level.fsm
@@ -1,0 +1,272 @@
+native
+{
+#ifdef TOP_LEVEL_DEBUG
+#include <stdio.h>
+#include "test.h"
+#endif
+#include <stdbool.h>
+
+#define EVENT_IS_NOT_EXCLUDED_FROM_LOG(e) (e != THIS(e6))
+}
+
+/**
+  After its own initialization, this machine transitions to its
+    second state, in which it uses the first two of its sub machines
+    to acommplish other initialization chores.  The third sub machine
+    is then run, and the top level transitions into its third state.
+
+    The machine remains in its third state for the rest of its life
+    responding to e5 by re-running sub machine 2, followed by sub
+    machine 3.
+*/
+machine top_level
+{
+
+   data
+   {
+      int  field1;
+      char field2[16];
+   }
+
+   /**
+     This event causes the machine to initialize itself, then
+     transition to state s2.  State s2 is the state from which
+     the initial sub machines are invoked.  When those machines
+     are finished, the top level machine will transition to
+     its "steady state."
+   */
+   event e1;
+
+   /**
+     sub_machine1 is finished.
+   */
+   event e2;
+
+   /**
+     sub_machine2 is finished.
+   */
+   event e3;
+
+   /**
+     sub_machine3 is finished.
+   */
+   event e4;
+
+   /**
+     It is time to do the periodic chore.  This chore requires that 
+     sub machine 2 be run, followed by sub machine 3.
+   */
+   event e5;
+
+   /**
+      This is the "dispatch loop" event.
+   */
+   event e6;
+
+   /**
+     This is another event to be passed to some sub-machines.
+   */
+   event e7;
+
+	/* we are done */
+	event e8;
+
+   /**
+     startup state; initialize the machine when e1 happens.
+   */
+   state s1;
+
+   /**
+     Execute the first two sub machines in this state
+   */
+   state s2;
+
+   /**
+     When e5 is received in this state, execute sub machines 2 and 3.
+   */
+   state s3;
+
+   /* this will be our parking state when done */
+   state s4 inhibits submachines;
+
+    /**
+      This machine's happy path is e1 then e2, finishing with e3.
+    */
+    native
+    {
+      
+		#undef EVENT_IS_NOT_EXCLUDED_FROM_LOG
+		#define EVENT_IS_NOT_EXCLUDED_FROM_LOG(e) (e != THIS(e6))
+    }
+    machine sub_machine1
+    {
+        data
+        {
+            int  field1;
+            char field2[16];
+        }
+
+       /**
+         This event starts sub_machine1.
+       */
+		   event e1;
+       event e2;
+       event e3;
+
+	event parent::e6, parent::e7 data translator translate_e7_data;
+
+		   state s1;
+       state s2;
+
+       /**
+         Arriving in this state means sub_machine1's job is done.
+       */
+       state s3;
+		
+		   action a1[e1, s1] transition s2;
+		   action a2[e2, s2] transition s3;
+
+       /**
+         This action returns the parent's event e3 to signal sub
+           machine completion.
+       */
+		   action a3[e3, s3] transition s1;
+
+       /**
+         handle the parent e7 event
+       */
+       action handle_e7[e7, (s1, s2, s3)];
+
+		}
+		
+    /**
+      This machine's happy path is e1 then e2, finishing with e3.
+    */
+    native
+    {
+      
+		#undef EVENT_IS_NOT_EXCLUDED_FROM_LOG
+		#define EVENT_IS_NOT_EXCLUDED_FROM_LOG(e) (e != THIS(e6))
+    }
+		machine sub_machine2
+		{
+       /**
+         This event starts sub_machine2.
+       */
+		   event e1;
+       event e2;
+       event e3, parent::e6;
+
+		   state s1;
+       state s2;
+
+       /**
+         Arriving in this state means sub_machine1's job is done.
+       */
+       state s3;
+		
+		   action a1[e1, s1] transition s2;
+		   action a2[e2, s2] transition s3;
+
+       /**
+         This action returns the parent's event e4 to signal sub
+           machine completion.
+       */
+		   action a3[e3, s3] transition s1;
+
+       a3 returns parent::e4;
+		}
+		
+    /**
+      This machine's happy path is e1 then e2, finishing with e3.
+
+      It is not necessary to inform the parent when this machine
+        is finished.
+    */
+    native
+    {
+      
+		#undef EVENT_IS_NOT_EXCLUDED_FROM_LOG
+    }
+		machine sub_machine3
+		{
+       /**
+         This event starts sub_machine3.
+       */
+		   event e1;
+       event e2;
+       event e3;
+       event parent::e7;
+
+		   state s1;
+       state s2;
+		
+       /**
+         Arriving in this state means sub_machine1's job is done.
+       */
+       state s3;
+		
+		   action a1[e1, s1] transition s2;
+		   action a2[e2, s2] transition s3;
+
+       /**
+         This machine will return the parent's "noEvent" bringing
+           the current action sequence to an end.
+       */
+		   action a3[e3, s3] transition s1;
+
+       /**
+         handle the parent e7 event
+       */
+       action handle_e7[e7, (s1, s2, s3)];
+
+		}
+		
+    /**
+      Do a top level action
+    */
+   action a1[e1,s1] transition s2;
+
+   /**
+     Make sub_machine1 the active machine, then
+       start it working by returning its first
+       event.
+   */
+   action activate_sub_machine1[e2, s2];
+
+   /**
+     Make sub_machine2 the active machine, then
+       start it working by returning its first
+       event.
+   */
+   action activate_sub_machine2[e3, s2];
+
+   /**
+     Make sub_machine3 the active machine, then
+       start it working by returning its first
+       event.  Trasition to s3, which is the
+       "steady state" for this machine.
+   */
+   action activate_sub_machine3[e4, s2] transition s3;
+
+   /**
+     In the steady state, e5 triggers us to re-run sub
+     machines 2 and 3.
+   */
+   action activate_sub_machine2[e5, s3];
+   action activate_sub_machine3[e4, s3];
+
+   action handle_dispatch[e6, (s1, s2, s3)];
+   action handle_other_passed_event[e7, (s1, s2, s3)];
+
+	transition [e8, (s1, s2, s3)] s4;
+
+   activate_sub_machine1 returns sub_machine1::e1;
+   activate_sub_machine2 returns sub_machine2::e1, noEvent;
+   activate_sub_machine3 returns noEvent, sub_machine3::e1;
+
+   handle_dispatch           returns noEvent;
+   handle_other_passed_event returns noEvent;
+
+}
+


### PR DESCRIPTION
See the action files in the new full_test37 for an illustration of the use of the new macros.  This makes it easier to move action functions between machines.