### PR TITLE
document comments picked up from namespace designations

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -345,6 +345,10 @@ void {
 
 parent {
 					#ifndef LEX_DEBUG
+
+         yylval.charData = currDocCmnt ? currDocCmnt : NULL;
+         currDocCmnt     = NULL;
+
 					return PARENT;
 					#else
 					printf("%s\n",strings[PARENT]);

--- a/src/parser.y
+++ b/src/parser.y
@@ -65,9 +65,10 @@ void yyerror(char *);
  pMACHINE_PREFIX          pmachine_prefix;
 }
 
-%token MACHINE_KEY TRANSITION_KEY STATE_KEY EVENT_KEY ACTION_KEY ON PARENT NAMESPACE
+%token MACHINE_KEY TRANSITION_KEY STATE_KEY EVENT_KEY ACTION_KEY ON NAMESPACE
 %token REENTRANT ACTIONS RETURN STATES EVENTS RETURNS EXTERNAL EQUALS VOID TRANSLATOR_KEY
 %token IMPLEMENTATION_KEY INHIBITS SUBMACHINES
+%token <charData>	PARENT
 %token <charData>	NATIVE_KEY
 %token <charData>	NATIVE_BLOCK
 %token <charData>	DATA_KEY
@@ -114,6 +115,7 @@ void yyerror(char *);
 %type <pid_info>                 namespace_event_ref
 %type <pid_info>                 event_data
 %type <pid_info>                 state
+%type <charData>                 parent_namespace
 
 %%
 
@@ -1214,6 +1216,9 @@ parent_namespace: PARENT NAMESPACE
         yyerror("parent namespace invoked in top-level machine");
 
     id_list = pmachineInfo->parent->id_list;
+
+    /* this picks up any doc comment */
+ 	 $$ = $1;
   }
   ;
 
@@ -1259,7 +1264,8 @@ event_decl_list:	EVENT_KEY ID external_designation
 
            pid->type_data.event_data.data_translator     = $4;
            pid->type_data.event_data.shared_with_parent  = true;
-           pid->powningMachine = pmachineInfo;
+           pid->powningMachine                           = pmachineInfo;
+ 					pid->docCmnt                                  = $2;
 
  					if (NULL == (add_to_list($$,pid)))
  						yyerror("Out of memory");
@@ -1309,7 +1315,8 @@ event_decl_list:	EVENT_KEY ID external_designation
 
            pid->type_data.event_data.data_translator     = $5;
            pid->type_data.event_data.shared_with_parent  = true;
-           pid->powningMachine = pmachineInfo;
+           pid->powningMachine                           = pmachineInfo;
+ 					pid->docCmnt                                  = $3;
 
  					if (NULL == (add_to_list($$,pid)))
  						yyerror("Out of memory");

--- a/test/full_test30/top_level.fsm
+++ b/test/full_test30/top_level.fsm
@@ -105,6 +105,7 @@ machine top_level
        event e2;
        event e3;
 
+	/** Is this comment picked up? */
 	event parent::e6, parent::e7 data translator translate_e7_data;
 
 		   state s1;


### PR DESCRIPTION
lexer returns current document comment as yylval for parent keyword.
parser adds this doc comment to pid being created.
No other modifications needed in html generator.