### PR TITLE
entry and exit functions can be designated for states

### DIFF
--- a/src/fsm_c_common.h
+++ b/src/fsm_c_common.h
@@ -50,6 +50,7 @@ struct _iterator_callback_helper_
    char          *parent_cp;
    bool          needNoOp;
    bool          first;
+   bool          define;  //as opposed to "declare"
 };
 
 struct _c_machine_data_
@@ -80,16 +81,17 @@ int  initCMachine(pFSMOutputGenerator,char*);
 int  initCSubMachine(pFSMOutputGenerator,char*);
 void closeCMachine(pFSMOutputGenerator,int);
 
-char          * commonHeaderStart(pCMachineData, pMACHINE_INFO, char *);
-void            commonHeaderEnd(pCMachineData, pMACHINE_INFO, char *, bool);
-void            generateInstance(pCMachineData, pMACHINE_INFO, char *, char *);
-void            defineWeakActionFunctionStubs(pCMachineData, pMACHINE_INFO, char *);
-void            defineWeakNoActionFunctionStubs(pCMachineData, pMACHINE_INFO, char *);
-void            writeStateTransitions(pCMachineData, pMACHINE_INFO, char *);
-void            subMachineWriteStateTransitions(pCMachineData, pMACHINE_INFO, char *);
-void            writeDebugInfo(pCMachineData, pMACHINE_INFO, char *);
-pCMachineData   newCMachineData(char *);
-void            destroyCMachineData(pCMachineData, int);
+char          * commonHeaderStart(pCMachineData,pMACHINE_INFO,char*);
+void            commonHeaderEnd(pCMachineData,pMACHINE_INFO,char*,bool);
+void            generateInstance(pCMachineData,pMACHINE_INFO,char*,char*);
+void            defineWeakActionFunctionStubs(pCMachineData,pMACHINE_INFO,char*);
+void            defineWeakNoActionFunctionStubs(pCMachineData,pMACHINE_INFO,char*);
+void            defineWeakStateEntryAndExitFunctionStubs(pCMachineData,pMACHINE_INFO,char*);
+void            writeStateTransitions(pCMachineData,pMACHINE_INFO,char*);
+void            subMachineWriteStateTransitions(pCMachineData,pMACHINE_INFO,char*);
+void            writeDebugInfo(pCMachineData,pMACHINE_INFO,char*);
+pCMachineData   newCMachineData(char*);
+void            destroyCMachineData(pCMachineData,int);
 bool            assignExternalEventValues(pMACHINE_INFO);
 bool            declare_transition_fn_for_when_actions_return_states(pLIST_ELEMENT,void*);
 bool            sub_machine_declare_transition_fn_for_when_actions_return_states(pLIST_ELEMENT,void*);
@@ -98,23 +100,27 @@ bool            sub_machine_declare_transition_fn_for_when_actions_return_events
 bool            declare_state_only_transition_functions_for_when_actions_return_states(pLIST_ELEMENT,void*);
 bool            sub_machine_declare_state_only_transition_functions_for_when_actions_return_states(pLIST_ELEMENT,void*);
 bool            declare_state_only_transition_functions_for_when_actions_return_events(pLIST_ELEMENT,void*);
+bool            declare_state_entry_and_exit_functions(pLIST_ELEMENT,void*);
+bool            define_state_entry_and_exit_functions(pLIST_ELEMENT,void*);
 bool            sub_machine_declare_state_only_transition_functions_for_when_actions_return_events(pLIST_ELEMENT,void*);
 bool            declare_data_translator_functions(pLIST_ELEMENT,void*);
 bool            define_weak_data_translator_functions(pLIST_ELEMENT,void*);
 
-char          * subMachineHeaderStart(pCMachineData, pMACHINE_INFO, char *);
-void            subMachineHeaderEnd(pCMachineData, pMACHINE_INFO, char *, bool);
-void            defineSubMachineIF(pCMachineData, pMACHINE_INFO, char *);
-void            possiblyDefineSubMachineSharedEventStructures(pCMachineData, pMACHINE_INFO, char *);
-void            defineSubMachineArray(pCMachineData, pMACHINE_INFO, char *);
+char          * subMachineHeaderStart(pCMachineData,pMACHINE_INFO,char*);
+void            subMachineHeaderEnd(pCMachineData,pMACHINE_INFO,char*,bool);
+void            defineSubMachineIF(pCMachineData,pMACHINE_INFO,char*);
+void            possiblyDefineSubMachineSharedEventStructures(pCMachineData,pMACHINE_INFO,char*);
+void            defineSubMachineArray(pCMachineData,pMACHINE_INFO,char*);
 bool            declare_sub_machine_action_function(pLIST_ELEMENT,void*);
 bool            print_sub_machine_if(pLIST_ELEMENT,void*);
 void            defineSubMachineWeakActionFunctionStubs(pCMachineData,pMACHINE_INFO,char*);
 void            defineEventPassingActions(pCMachineData,pMACHINE_INFO,char*);
 void            defineSubMachineWeakDataTranslatorStubs(pCMachineData,pMACHINE_INFO,char*);
-void            defineSubMachineFinder(pCMachineData, pMACHINE_INFO, char *);
+void            defineSubMachineFinder(pCMachineData,pMACHINE_INFO,char*);
 bool            declare_action_function(pLIST_ELEMENT,void*);
 void            declareSubMachineManagers(pCMachineData,pMACHINE_INFO,char*);
+void            declareStateEntryAndExitManagers(pCMachineData,pMACHINE_INFO,char*);
+void            defineStateEntryAndExitManagers(pCMachineData,pMACHINE_INFO,char*);
 
 #endif
 

--- a/src/fsm_html.c
+++ b/src/fsm_html.c
@@ -545,15 +545,66 @@ void writeHTMLWriter(pFSMOutputGenerator pfsmog, pMACHINE_INFO pmi)
 	fprintf(pfsmhtmlog->pmd->htmlFile,"</tr>\n");
 	
 	for (s = 0; s < pmi->state_list->count; s++) {
+
+     bool something_printed = false;
 	
 		pid = statePidByIndex(pmi,s);
 
 		fprintf(pfsmhtmlog->pmd->htmlFile,"<tr>\n");
-		fprintf(pfsmhtmlog->pmd->htmlFile,"<td class=\"label\">%s</td>\n"
+		fprintf(pfsmhtmlog->pmd->htmlFile,"<td class=\"label\">%s</td>\n<td>\n"
 			, pid->name);
-		fprintf(pfsmhtmlog->pmd->htmlFile,"<td>%s</td>\n"
-			, pid->docCmnt ? pid->docCmnt : "&nbsp;");
-		fprintf(pfsmhtmlog->pmd->htmlFile,"</tr>\n");
+
+    if (pid->docCmnt)
+    {
+       fprintf(pfsmhtmlog->pmd->htmlFile
+               , "<p>%s</p>\n"
+               , pid->docCmnt
+               );
+       something_printed = true;
+    }
+
+    if (pid->type_data.state_data.state_flags & sfHasEntryFn)
+    {
+       fprintf(pfsmhtmlog->pmd->htmlFile
+               , "<p>On Entry: %s%s</p>\n"
+               , pid->type_data.state_data.entry_fn
+                 ? pid->type_data.state_data.entry_fn->name
+                 : "onEntryTo_"
+               , pid->type_data.state_data.entry_fn
+                 ? ""
+                 : pid->name
+               );
+       something_printed = true;
+    }
+
+    if (pid->type_data.state_data.state_flags & sfHasExitFn)
+    {
+       fprintf(pfsmhtmlog->pmd->htmlFile
+               , "<p>On Exit: %s%s</p>\n"
+               , pid->type_data.state_data.exit_fn
+                 ? pid->type_data.state_data.exit_fn->name
+                 : "onExitTo_"
+               , pid->type_data.state_data.exit_fn
+                 ? ""
+                 : pid->name
+               );
+       something_printed = true;
+    }
+
+    if (pid->type_data.state_data.state_flags & sfInibitSubMachines)
+    {
+       fprintf(pfsmhtmlog->pmd->htmlFile
+               , "<p>Inhibits Sub-machines</p>\n"
+               );
+       something_printed = true;
+    }
+
+    if (!something_printed)
+    {
+       fprintf(pfsmhtmlog->pmd->htmlFile,"&nbsp;");
+    }
+
+    fprintf(pfsmhtmlog->pmd->htmlFile, "</td></tr>\n");
 
 	}
 

--- a/src/fsm_priv.h
+++ b/src/fsm_priv.h
@@ -53,6 +53,8 @@ typedef enum {
 typedef enum {
    sfNone
    , sfInibitSubMachines = 1
+   , sfHasEntryFn        = 2
+   , sfHasExitFn         = 4
 } STATE_FLAGS;
 
 #define ACTIONS_RETURN_FLAGS (mfActionsReturnStates | mfActionsReturnVoid)
@@ -78,6 +80,8 @@ typedef union  _pid_type_data_           PID_TYPE_DATA,           *pPID_TYPE_DAT
 struct _state_data_
 {
    STATE_FLAGS state_flags;
+   pID_INFO    entry_fn;
+   pID_INFO    exit_fn;
 };
 
 struct _event_data_
@@ -108,6 +112,8 @@ struct _iterator_helper_
    char          *cp;
    char          *parent_cp;
    int           event;
+   unsigned      *counter0;
+   unsigned      *counter1;
 };
 
 
@@ -207,6 +213,8 @@ struct _machine_info_ {
   int           shared_event_count;
   pLIST         id_list;
   bool          has_single_pai_events;
+  bool          states_with_entry_fns_count;
+  bool          states_with_exit_fns_count;
 };
 
 /* lexer id list handlers */
@@ -239,6 +247,7 @@ void count_sub_machine_inhibitors(pLIST,unsigned*);
 void count_parent_event_referenced(pLIST,unsigned*);
 void count_shared_events(pLIST,unsigned*);
 void count_data_translators(pLIST,unsigned*);
+void count_states_with_entry_exit_fns(pLIST,unsigned*,unsigned*);
 bool populate_action_array(pMACHINE_INFO,FILE*);
 int  copyFileContents(const FILE*,const char*);
 void addNativeImplementationIfThereIsAny(pMACHINE_INFO, FILE*);

--- a/src/fsm_statistics.c
+++ b/src/fsm_statistics.c
@@ -186,6 +186,14 @@ static bool write_machine_statistics(pLIST_ELEMENT pelem, void *data)
           , pmi->state_list->count
           );
 
+   printf("number of states with entry fns: %u\n"
+          , pmi->states_with_entry_fns_count
+          );
+
+   printf("number of states with exit fns: %u\n"
+          , pmi->states_with_exit_fns_count
+          );
+
    printf("number of actions: %u\n"
           , pmi->action_list->count
           );

--- a/src/fsm_utils.c
+++ b/src/fsm_utils.c
@@ -735,6 +735,25 @@ static bool count_data_xlate(pLIST_ELEMENT pelem, void *data)
    return false;
 }
 
+static bool count_entry_and_exit_handlers(pLIST_ELEMENT pelem, void *data)
+{
+   pID_INFO         pstate = (pID_INFO) pelem->mbr;
+   pITERATOR_HELPER pih    = (pITERATOR_HELPER) data;
+
+   if (pstate->type_data.state_data.state_flags & sfHasEntryFn)
+   {
+      (*pih->counter0)++;
+   }
+
+   if (pstate->type_data.state_data.state_flags & sfHasExitFn)
+   {
+      (*pih->counter1)++;
+   }
+
+   return false;
+
+}
+
 void count_external_declarations(pLIST plist, unsigned *counter)
 {
    iterate_list(plist, count_external, counter);
@@ -758,6 +777,18 @@ void count_shared_events(pLIST plist, unsigned *counter)
 void count_data_translators(pLIST plist, unsigned *counter)
 {
    iterate_list(plist, count_data_xlate, counter);
+}
+
+void count_states_with_entry_exit_fns(pLIST pstate_list, unsigned *entry_counter, unsigned *exit_counter)
+{
+   ITERATOR_HELPER ih;
+
+   *entry_counter = *exit_counter = 0;
+
+   ih.counter0 = entry_counter;
+   ih.counter1 = exit_counter;
+   
+   iterate_list(pstate_list, count_entry_and_exit_handlers, &ih);
 }
 
 /**

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -379,6 +379,22 @@ all {
 					#endif
 				}
 
+entry {
+					#ifndef LEX_DEBUG
+					return ENTRY;
+					#else
+					printf("%s\n",strings[ENTRY]);
+					#endif
+				}
+
+exit {
+					#ifndef LEX_DEBUG
+					return EXIT;
+					#else
+					printf("%s\n",strings[EXIT]);
+					#endif
+				}
+
 :: {
 					#ifndef LEX_DEBUG
 					return NAMESPACE;

--- a/src/lexer_debug.c
+++ b/src/lexer_debug.c
@@ -63,5 +63,7 @@ char *strings[]  = {
   , "INHIBITS"
   , "SUBMACHINES"
   , "ALL"
+  , "ENTRY"
+  , "EXIT"
 };
 

--- a/src/lexer_debug.h
+++ b/src/lexer_debug.h
@@ -64,6 +64,8 @@ enum states {
   , INHIBITS
   , SUBMACHINES
   , ALL
+  , ENTRY
+  , EXIT
 };
 
 extern char *strings[];


### PR DESCRIPTION
tests cover "actions return events" machines, including sub-machines and actions return state machines.