### PR TITLE
58 event cross reference includes too many numevents and omits numallevents

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -254,6 +254,9 @@ char* commonHeaderStart(pCMachineData pcmw, pMACHINE_INFO pmi, char *arrayName)
             iterate_list(pmi->machine_list, print_sub_machine_event_cross_reference, &helper);
          }
 
+         helper.pparent   = NULL;
+         print_event_cross_reference_entry("numAllEvents", &helper);
+
          fprintf(pcmw->hFile
                  ,"\n*/\n"
                  );
@@ -1431,8 +1434,6 @@ static bool print_sub_machine_event_cross_reference(pLIST_ELEMENT pelem, void *d
    {
       print_event_cross_reference_entry("noEvent", pih);
    }
-
-   print_event_cross_reference_entry("numEvents", pih);
 
    return false;
 }

--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -126,6 +126,56 @@ void closeCMachine(pFSMOutputGenerator pfsmog, int how)
    destroyCMachineData(pfsmcog->pcmd, how);
 }
 
+void addEventCrossReference(pCMachineData pcmw, pMACHINE_INFO pmi, pITERATOR_HELPER pih)
+{
+   bool canAssignExternals;
+
+   if ((canAssignExternals = (pmi->external_event_designation_count > 0)) == true)
+   {
+      if ((canAssignExternals = assignExternalEventValues(pmi)) == false)
+      {
+         printf("warning: cannot print cross reference with external designations\n");
+         return;
+      }
+   }
+
+   unsigned enum_val = 0;
+
+   fprintf(pcmw->hFile
+           , "/*\n\tEvent Cross Reference:\n\n"
+          );
+
+   pih->first     = true;
+   pih->counter0  = &enum_val;
+   pih->pparent   = NULL;
+
+   iterate_list(pmi->event_list, print_event_cross_reference, pih);
+
+   if (
+       !(pmi->modFlags & mfActionsReturnStates)
+       && !(pmi->modFlags & mfActionsReturnVoid)
+      )
+   {
+      print_event_cross_reference_entry("noEvent", pih);
+   }
+
+   print_event_cross_reference_entry("numEvents", pih);
+
+   if (pmi->machine_list)
+   {
+      iterate_list(pmi->machine_list, print_sub_machine_event_cross_reference, pih);
+
+      pih->pparent   = NULL;
+      print_event_cross_reference_entry("numAllEvents", pih);
+   }
+
+   fprintf(pcmw->hFile
+           , "\n*/\n"
+          );
+
+   pih->pparent = pmi;
+}
+
 char* commonHeaderStart(pCMachineData pcmw, pMACHINE_INFO pmi, char *arrayName)
 {
    char					*cp;
@@ -216,55 +266,7 @@ char* commonHeaderStart(pCMachineData pcmw, pMACHINE_INFO pmi, char *arrayName)
 
    if (add_event_cross_reference)
    {
-      do
-      {
-         if ((canAssignExternals = (pmi->external_event_designation_count > 0)) == true)
-         {
-            if ((canAssignExternals = assignExternalEventValues(pmi)) == false)
-            {
-               printf("warning: cannot print cross reference with external designations\n");
-               break;
-            }
-         }
-
-         unsigned enum_val = 0;
-
-         fprintf(pcmw->hFile
-                 ,"/*\n\tEvent Cross Reference:\n\n"
-                 );
-
-         helper.first     = true;
-         helper.counter0  = &enum_val;
-         helper.pparent   = NULL;
-
-         iterate_list(pmi->event_list, print_event_cross_reference, &helper);
-
-         if (
-             !(pmi->modFlags & mfActionsReturnStates)
-             && !(pmi->modFlags & mfActionsReturnVoid)
-            )
-         {
-            print_event_cross_reference_entry("noEvent", &helper);
-         }
-
-         print_event_cross_reference_entry("numEvents", &helper);
-
-         if (pmi->machine_list)
-         {
-            iterate_list(pmi->machine_list, print_sub_machine_event_cross_reference, &helper);
-         }
-
-         helper.pparent   = NULL;
-         print_event_cross_reference_entry("numAllEvents", &helper);
-
-         fprintf(pcmw->hFile
-                 ,"\n*/\n"
-                 );
-      }
-      while (0);
-
-      helper.pparent = pmi;
-      helper.pmi     = pmi;
+      addEventCrossReference(pcmw, pmi, &helper);
    }
 
    /* put the event enum into the header file */

--- a/src/fsm_c_common.h
+++ b/src/fsm_c_common.h
@@ -82,6 +82,7 @@ int  initCSubMachine(pFSMOutputGenerator,char*);
 void closeCMachine(pFSMOutputGenerator,int);
 
 char          * commonHeaderStart(pCMachineData,pMACHINE_INFO,char*);
+void            addEventCrossReference(pCMachineData,pMACHINE_INFO,pITERATOR_HELPER);
 void            commonHeaderEnd(pCMachineData,pMACHINE_INFO,char*,bool);
 void            generateInstance(pCMachineData,pMACHINE_INFO,char*,char*);
 void            defineWeakActionFunctionStubs(pCMachineData,pMACHINE_INFO,char*);

--- a/test/full_test50/top_level.h.canonical
+++ b/test/full_test50/top_level.h.canonical
@@ -66,12 +66,11 @@ NEW_MACHINE *p##A = &A;
 	    8  newMachine_subMachine1_ee2
 	    9  newMachine_subMachine1_ee3
 	   10  newMachine_subMachine1_noEvent
-	   11  newMachine_subMachine1_numEvents
-	   12  newMachine_subMachine2_eee1
-	   13  newMachine_subMachine2_eee2
-	   14  newMachine_subMachine2_eee3
-	   15  newMachine_subMachine2_noEvent
-	   16  newMachine_subMachine2_numEvents
+	   11  newMachine_subMachine2_eee1
+	   12  newMachine_subMachine2_eee2
+	   13  newMachine_subMachine2_eee3
+	   14  newMachine_subMachine2_noEvent
+	   15  subMachine2_numAllEvents
 
 */
 typedef enum {


### PR DESCRIPTION
Sub machines do not use numEvents
When sub machines are present, numAllEvents is needed.
Removed do{}while(0) in favor of called function.