### PR TITLE
102 native impl generation location

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -247,10 +247,6 @@ void writeCFilePreambles(pCMachineData pcmd, bool sub_machine)
 				fprintf(pcmd->cFile, "#include <stddef.h>\n\n"
 						);
 
-				/* protect ourselves from not having DBG_PRINTF defined */
-				fprintf(pcmd->cFile, "#ifndef DBG_PRINTF\n#define DBG_PRINTF(...)\n");
-
-				fprintf(pcmd->cFile, "#endif\n\n");
 
 			}
 			else
@@ -2904,21 +2900,45 @@ void addNativeImplementationPrologIfThereIsAny(pMACHINE_INFO pmi, FILE *fout)
 {
    if (pmi->native_impl_prologue)
    {
+	  fprintf(fout
+			  , "/* Begin Native Implementation Prolog */\n\n"
+			  );
+
       fprintf(fout
               , "%s\n"
               , pmi->native_impl_prologue
               );
+
+	  fprintf(fout
+			  , "/* End Native Implementation Prolog */\n\n"
+			  );
+
    }
+
+   /* protect ourselves from not having DBG_PRINTF defined */
+   fprintf(fout, "\n#ifndef DBG_PRINTF\n#define DBG_PRINTF(...)\n");
+
+   fprintf(fout, "#endif\n\n");
+
 }
 
 void addNativeImplementationEpilogIfThereIsAny(pMACHINE_INFO pmi, FILE *fout)
 {
    if (pmi->native_impl_epilogue)
    {
+	  fprintf(fout
+			  , "/* Begin Native Implementation Epilog */\n\n"
+			  );
+
       fprintf(fout
               , "%s\n"
               , pmi->native_impl_epilogue
               );
+
+	  fprintf(fout
+			  , "/* End Native Implementation Epilog */\n\n"
+			  );
+
    }
 }
 

--- a/test/full_test56/top_level.c.canonical
+++ b/test/full_test56/top_level.c.canonical
@@ -7,6 +7,7 @@
 #include "top_level_priv.h"
 #include <stddef.h>
 
+
 #ifndef DBG_PRINTF
 #define DBG_PRINTF(...)
 #endif

--- a/test/full_test71/sub_machine1.c.canonical
+++ b/test/full_test71/sub_machine1.c.canonical
@@ -7,6 +7,7 @@
 #include "sub_machine1_priv.h"
 #include <stddef.h>
 
+
 #ifndef DBG_PRINTF
 #define DBG_PRINTF(...)
 #endif

--- a/test/full_test71/sub_machine2.c.canonical
+++ b/test/full_test71/sub_machine2.c.canonical
@@ -7,6 +7,7 @@
 #include "sub_machine2_priv.h"
 #include <stddef.h>
 
+
 #ifndef DBG_PRINTF
 #define DBG_PRINTF(...)
 #endif

--- a/test/full_test71/sub_machine3.c.canonical
+++ b/test/full_test71/sub_machine3.c.canonical
@@ -7,6 +7,7 @@
 #include "sub_machine3_priv.h"
 #include <stddef.h>
 
+
 #ifndef DBG_PRINTF
 #define DBG_PRINTF(...)
 #endif

--- a/test/full_test71/top_level.c.canonical
+++ b/test/full_test71/top_level.c.canonical
@@ -7,6 +7,7 @@
 #include "top_level_priv.h"
 #include <stddef.h>
 
+
 #ifndef DBG_PRINTF
 #define DBG_PRINTF(...)
 #endif


### PR DESCRIPTION
Protection against missing DBG_PRINTF macro definition moved to post inclusion of any native implementation prologue.

Since an additional newline was added to insure that the protection lines are separated by an empty line from any prologue, some tests which examine output source code were adjusted.