### PR TITLE
94 data block wont accept certain c constructs

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -894,6 +894,13 @@ void generateInstance(pCMachineData pcmd, pMACHINE_INFO pmi, char *arrayName)
 {
    FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
+   if (pmi->data)
+   {
+	   fprintf(pcmd->cFile
+			   , "#ifndef INIT_FSM_DATA\n#error INIT_FSM_DATA must be defined\n#endif\n\n"
+			   );
+   }
+
    /* instantiate the machine and the pointer to it */
    /* the (empty) data struct and the state */
    fprintf(pcmd->cFile

--- a/src/fsm_priv.h
+++ b/src/fsm_priv.h
@@ -183,6 +183,7 @@ typedef enum
    , dtt_union 
    , dtt_struct 
 } DATA_TYPE_TYPE;
+
 union _data_type_union_
 {
    pID_INFO         name;
@@ -191,16 +192,17 @@ union _data_type_union_
 
 struct _data_type_struct_
 {
-   DATA_TYPE_TYPE  dtt;
-   DATA_TYPE_UNION dtu;
+   DATA_TYPE_TYPE    dtt;
+   DATA_TYPE_UNION   dtu;
+   unsigned          indirection_level;
+   bool              is_array;
+   char            * dimension;
 };
 
 struct _data_field_              
 {
    pID_INFO            data_field_name;
    pDATA_TYPE_STRUCT   pdts;
-   bool                isPointer;
-   char              * dimension;
 };
 
 struct _iterator_helper_

--- a/src/fsm_utils.c
+++ b/src/fsm_utils.c
@@ -1375,45 +1375,48 @@ bool print_data_field(pLIST_ELEMENT pelem, void *data)
    pITERATOR_HELPER pih       = (pITERATOR_HELPER) data;
    pDATA_FIELD pdf            = (pDATA_FIELD)      pelem->mbr;
 
+   print_tab_levels(pih->fout, pih->tab_level);
    switch (pdf->pdts->dtt)
    {
    case dtt_simple:
-      print_tab_levels(pih->fout, pih->tab_level);
-      fprintf(pih->fout
-              , "%s %s %s %s%s%s;\n"
-              , pdf->pdts->dtu.name->name
-              , pdf->isPointer ? "*" : ""
-              , pdf->data_field_name->name
-              , pdf->dimension ? "[" : ""
-              , pdf->dimension ? pdf->dimension : ""
-              , pdf->dimension ? "]" : ""
-              );
+      fprintf(pih->fout, "%s", pdf->pdts->dtu.name->name);
       break;
    case dtt_struct:
-      print_tab_levels(pih->fout, pih->tab_level);
       pih->tab_level++;
       fprintf(pih->fout , "struct {\n" );
       iterate_list(pdf->pdts->dtu.members, print_data_field, pih);
       pih->tab_level--;
       print_tab_levels(pih->fout, pih->tab_level);
-      fprintf(pih->fout
-              , "} %s;\n"
-              , pdf->data_field_name->name
-              );
+      fprintf(pih->fout, "}");
       break;
    case dtt_union:
-      print_tab_levels(pih->fout, pih->tab_level);
       pih->tab_level++;
       fprintf(pih->fout , "union {\n" );
       iterate_list(pdf->pdts->dtu.members, print_data_field, pih);
       pih->tab_level--;
       print_tab_levels(pih->fout, pih->tab_level);
-      fprintf(pih->fout
-              , "} %s;\n"
-              , pdf->data_field_name->name
-              );
+      fprintf(pih->fout, "}");
       break;
    }
+
+   for (unsigned level = 0; level < pdf->pdts->indirection_level; level++)
+   {
+       fprintf(pih->fout
+               , "%s*"
+               , level ? "" : " "
+               );
+   }
+   fprintf(pih->fout, " %s", pdf->data_field_name->name);
+
+   if (pdf->pdts->is_array)
+   {
+       fprintf(pih->fout
+               , "[%s]"
+               , pdf->pdts->dimension ? pdf->pdts->dimension : ""
+               );
+   }
+
+   fprintf(pih->fout, ";\n");
 
    return false;
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -1850,9 +1850,25 @@ data_type : ID
  		 $$->dtu.members = $3;
 
    }
+   | data_type '*'
+   {
+    $$ = $1;
+    ($$->indirection_level)++;
+
+		 #ifdef PARSER_DEBUG
+		 fprintf(yyout
+            ,"found pointer data type: TYPE: %s; indirection_level: %u\n"
+            , $1->dtt == dtt_simple ? "simple"
+ 					   : $1->dtt == dtt_struct ? "struct"
+ 					     : "union"
+            , $1->indirection_level
+            );
+		 #endif
+   }
    ;
 
-data_field : data_type ID data_field_dimension ';'
+data_field : 
+   data_type ID data_field_dimension ';'
   {
 		 #ifdef PARSER_DEBUG
 		 fprintf(yyout
@@ -1868,21 +1884,21 @@ data_field : data_type ID data_field_dimension ';'
  	 if (($$ = calloc(1, sizeof(DATA_FIELD))) == NULL)
  	    yyerror("out of memory");
 
-    $$->pdts            = $1;
+   $$->pdts            = $1;
+   $$->pdts->is_array  = true;
+ 	 $$->pdts->dimension = $3;
  	 $$->data_field_name = $2;
- 	 $$->dimension       = $3;
 
   }
-  | data_type '*' ID data_field_dimension ';'
+  | data_type ID ';'
   {
 		 #ifdef PARSER_DEBUG
 		 fprintf(yyout
-            ,"found pointer data field: TYPE: %s; NAME: %s; dimension: %s\n"
+            ,"found data field: TYPE: %s; NAME: %s\n" 
             , $1->dtt == dtt_simple ? "simple"
  					   : $1->dtt == dtt_struct ? "struct"
  					     : "union"
-            , $3->name
-            , $4 ? $4 : "none"
+            , $2->name
             );
 		 #endif
 
@@ -1890,15 +1906,12 @@ data_field : data_type ID data_field_dimension ';'
  	    yyerror("out of memory");
 
     $$->pdts            = $1;
- 	 $$->isPointer       = true;
- 	 $$->data_field_name = $3;
- 	 $$->dimension       = $4;
-
+ 	 $$->data_field_name = $2;
 
   }
   ;
 
-data_field_dimension:
+data_field_dimension: '[' ']'
    {
        $$ = NULL;
    }

--- a/test/full_test88/Makefile
+++ b/test/full_test88/Makefile
@@ -1,0 +1,29 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -DFSM_DEBUG \
+         -DSUB_MACHINE1_DEBUG \
+         -DSUB_MACHINE2_DEBUG \
+         -DNEW_MACHINE_DEBUG \
+         -I../ \
+	 -Wall \
+	 -ggdb
+
+override FSM_FLAGS += --convenience-macros-in-public-header=false --generate-run-function=true -ts
+
+FSM_SRC = $(shell find . -name "*.fsm" -printf "%P ")
+
+TARGET=clean_fail_test_c
+
+include ../../fsmrules.mk
+
+include ../test.mk
+
+clean_fail_test_c: fail_test_c clean
+
+fail_test_c: top_level.h
+	@$(CC) -o $(CFLAGS) top_level.c $(CALL_FAILURE_A_SUCCESS)
+

--- a/test/full_test88/top_level.fsm
+++ b/test/full_test88/top_level.fsm
@@ -1,0 +1,147 @@
+/*
+	Here are some comments
+*/
+native prologue
+{
+#include "test.h"
+#define NUM_INTS (2)
+#define NUM_CHARS (20)
+
+#undef  FSM_END_CRITICAL
+
+}
+
+native epilogue
+{
+#define FSM_START_CRITICAL do_start_critical();
+#define FSM_END_CRITICAL do_end_critical();
+}
+
+reentrant machine newMachine
+ on transition baz;
+ native impl prologue
+ {
+	static void do_start_critical(void);
+	static void do_end_critical(void);
+ }
+
+ native impl epilogue
+ {
+	static void do_start_critical()
+   {
+     DBG_PRINTF("do_start_critical");
+   }
+
+	static void do_end_critical()
+   {
+     DBG_PRINTF("do_end_critical");
+   }
+ }
+{
+data
+{
+
+ struct
+ {
+  struct 
+  {
+  	int a[NUM_INTS];
+	int count_ints;
+  } foo;
+  
+  struct
+  {
+   float f;
+  } beep;
+ 
+  int   e3_int;
+  char  bop[NUM_CHARS];
+ } u;
+
+}
+
+event e1 data 
+ {
+  char  *  cp;
+ }
+, e2 data
+ {
+   int   i;
+   float f;
+ }
+ ;
+
+event e3 data 
+ {
+   int i;
+   struct
+   {
+     int i;
+     float f;
+   } s;
+ }
+ ;
+
+event e4;
+
+event eShared;
+
+state s1, s2, s3, s4;
+
+	/** a sub machine */
+  native
+  {
+  #if defined(INIT_FSM_DATA)
+  #undef INIT_FSM_DATA
+  #endif
+  #define INIT_FSM_DATA { .cp = NULL }
+  }
+  machine subMachine1 {
+		data
+      {
+			char *cp;
+      }
+		state ss1 on entry foo on exit bar
+           , ss2 on entry on exit
+           , ss3 on entry foo1
+           , ss4 on exit bar1
+           ;
+		event parent::eShared data translator eShared_dt 
+            , ee2 , ee3
+            ;
+
+		action aa1[eShared,ss1] transition ss2;
+		action aa2[ee2, ss1] transition ss3;
+	}
+
+	/** a second sub machine */
+  machine subMachine2 {
+		state sss1, sss2, sss3;
+		event eee1, eee2, eee3;
+
+		action aaa1[eee1,sss1] transition sss2;
+		action aaa2[eee2, sss1] transition sss3;
+	}
+
+	//This is a one-line comment
+	action a1[e1,s1];
+
+	/**
+		A Document Comment
+	*/
+	action a2[e1,(s2,s3)] transition transitionFn;
+	transition[(e2,e3),(s1,s2,s3)] transitionFn1;
+
+	transition [e4, (s1, s2, s3)] s4;
+
+	action doNothing[(e1, e2, e3, e4), s4];
+
+	action shareSharedEvent[eShared,(all)];
+
+	transitionFn  returns s1,s2;
+	transitionFn1 returns s2,s3;
+
+	a2 returns noEvent;
+
+}
+

--- a/test/parser/parser-test26.canonical
+++ b/test/parser/parser-test26.canonical
@@ -6,10 +6,10 @@ DEFINE INIT_FSM_DATA {{0,0}, 1}
 Native implementation
  copy this to the source file; 
 found simple data type id
-found data field: TYPE: simple; NAME: a; dimension: none
+found data field: TYPE: simple; NAME: a
 Starting data_fields list
 found struct data type
-found data field: TYPE: struct; NAME: foo; dimension: none
+found data field: TYPE: struct; NAME: foo
 Starting data_fields list
 Data block done
 found the start of a state declaration list
@@ -421,7 +421,7 @@ The 2 transition functions :
 				s3
 this machine has data
 struct {
-	int  a ;
+	int a;
 } foo;
 
 this machine has 2 sub-machines

--- a/test/parser/parser-test28.canonical
+++ b/test/parser/parser-test28.canonical
@@ -9,42 +9,43 @@ found simple data type id
 found data field: TYPE: simple; NAME: a; dimension: NUM_FLOATS
 Starting data_fields list
 found struct data type
-found data field: TYPE: struct; NAME: foo; dimension: none
+found data field: TYPE: struct; NAME: foo
 Starting data_fields list
 found simple data type id
-found data field: TYPE: simple; NAME: f; dimension: none
+found data field: TYPE: simple; NAME: f
 Starting data_fields list
 found struct data type
-found data field: TYPE: struct; NAME: beep; dimension: none
+found data field: TYPE: struct; NAME: beep
 Continuing data_fields list
 found simple data type name
 found data field: TYPE: simple; NAME: bop; dimension: 20
 Continuing data_fields list
 found union data type
-found data field: TYPE: union; NAME: u; dimension: none
+found data field: TYPE: union; NAME: u
 Starting data_fields list
 Data block done
 found simple data type id
-found pointer data field: TYPE: simple; NAME: cp; dimension: none
+found pointer data type: TYPE: simple; indirection_level: 1
+found data field: TYPE: simple; NAME: cp
 Starting data_fields list
 found simple data type name
-found data field: TYPE: simple; NAME: f; dimension: none
+found data field: TYPE: simple; NAME: f
 Continuing data_fields list
 Data block done
 found data fields
-char * cp ;
-float  f ;
+char * cp;
+float f;
 
 found simple data type name
-found data field: TYPE: simple; NAME: i; dimension: none
+found data field: TYPE: simple; NAME: i
 Starting data_fields list
 found simple data type name
-found data field: TYPE: simple; NAME: f; dimension: none
+found data field: TYPE: simple; NAME: f
 Continuing data_fields list
 Data block done
 found data fields
-int  i ;
-float  f ;
+int i;
+float f;
 
 added another id to the event declaration list
 The 2 events in this list:
@@ -53,23 +54,23 @@ The 2 events in this list:
 	1:	e2
 
 found simple data type name
-found data field: TYPE: simple; NAME: i; dimension: none
+found data field: TYPE: simple; NAME: i
 Starting data_fields list
 found simple data type name
-found data field: TYPE: simple; NAME: i; dimension: none
+found data field: TYPE: simple; NAME: i
 Starting data_fields list
 found simple data type name
-found data field: TYPE: simple; NAME: f; dimension: none
+found data field: TYPE: simple; NAME: f
 Continuing data_fields list
 found struct data type
-found data field: TYPE: struct; NAME: s; dimension: none
+found data field: TYPE: struct; NAME: s
 Continuing data_fields list
 Data block done
 found data fields
-int  i ;
+int i;
 struct {
-	int  i ;
-	float  f ;
+	int i;
+	float f;
 } s;
 
 The 1 events in this list:
@@ -113,7 +114,7 @@ found data field: TYPE: simple; NAME: i; dimension: 12
 Starting data_fields list
 Data block done
 found data fields
-int  i [12];
+int i[12];
 
 added another id to the event declaration list
 added another id to the event declaration list
@@ -473,12 +474,12 @@ The 2 transition functions :
 this machine has data
 union {
 	struct {
-		int  a [NUM_FLOATS];
+		int a[NUM_FLOATS];
 	} foo;
 	struct {
-		float  f ;
+		float f;
 	} beep;
-	int  bop [20];
+	int bop[20];
 } u;
 
 this machine has 2 sub-machines

--- a/test/parser/parser-test29.canonical
+++ b/test/parser/parser-test29.canonical
@@ -12,22 +12,22 @@ Native implementation prologue
 Native implementation
  copy this to the source file at the end; 
 found simple data type id
-found data field: TYPE: simple; NAME: a; dimension: none
+found data field: TYPE: simple; NAME: a
 Starting data_fields list
 found struct data type
-found data field: TYPE: struct; NAME: foo; dimension: none
+found data field: TYPE: struct; NAME: foo
 Starting data_fields list
 found simple data type id
-found data field: TYPE: simple; NAME: f; dimension: none
+found data field: TYPE: simple; NAME: f
 Starting data_fields list
 found struct data type
-found data field: TYPE: struct; NAME: beep; dimension: none
+found data field: TYPE: struct; NAME: beep
 Continuing data_fields list
 found simple data type name
-found data field: TYPE: simple; NAME: bop; dimension: none
+found data field: TYPE: simple; NAME: bop
 Continuing data_fields list
 found union data type
-found data field: TYPE: union; NAME: u; dimension: none
+found data field: TYPE: union; NAME: u
 Starting data_fields list
 Data block done
 found the start of a state declaration list
@@ -440,12 +440,12 @@ The 2 transition functions :
 this machine has data
 union {
 	struct {
-		int  a ;
+		int a;
 	} foo;
 	struct {
-		float  f ;
+		float f;
 	} beep;
-	int  bop ;
+	int bop;
 } u;
 
 this machine has 2 sub-machines

--- a/test/parser/parser-test30.canonical
+++ b/test/parser/parser-test30.canonical
@@ -1,14 +1,21 @@
-Native
+Native prologue
 
 Copy this to the header file.
 DEFINE INIT_FSM_DATA {{0,0}, 1}
 
-Native implementation
+Native epilogue
+
+Copy this to the header file at the end.
+
+Native implementation prologue
  copy this to the source file; 
+Native implementation
+ copy this to the source file at the end; 
 found simple data type id
 found data field: TYPE: simple; NAME: a
 Starting data_fields list
 found struct data type
+found pointer data type: TYPE: struct; indirection_level: 1
 found data field: TYPE: struct; NAME: foo
 Starting data_fields list
 found simple data type id
@@ -18,24 +25,28 @@ found struct data type
 found data field: TYPE: struct; NAME: beep
 Continuing data_fields list
 found simple data type name
+found pointer data type: TYPE: simple; indirection_level: 1
+found pointer data type: TYPE: simple; indirection_level: 2
 found data field: TYPE: simple; NAME: bop
 Continuing data_fields list
 found union data type
 found data field: TYPE: union; NAME: u
 Starting data_fields list
+found simple data type name
+found data field: TYPE: simple; NAME: f; dimension: 15
+Continuing data_fields list
+found simple data type id
+found data field: TYPE: simple; NAME: d; dimension: none
+Continuing data_fields list
+found simple data type id
+found data field: TYPE: simple; NAME: l; dimension: NUM_LONGS
+Continuing data_fields list
 Data block done
-added another id to the event declaration list
-added another id to the event declaration list
-The 3 events in this list:
-	0:	e1
-
-	1:	e2
-
-	2:	e3
-
 found the start of a state declaration list
 added another id to the state declaration list
 added another id to the state declaration list
+state s4 inhibits submachines
+state s4 has anonymous entry function
 added another id to the state declaration list
 The 4 states in this list :
 	0:	s1
@@ -45,6 +56,19 @@ The 4 states in this list :
 	2:	s3
 
 	3:	s4
+
+added another id to the event declaration list
+added another id to the event declaration list
+The 3 events in this list:
+	0:	e1
+
+	1:	e2
+
+	2:	e3
+
+External designation = BAR
+The 1 events in this list:
+	0:	e4 = BAR
 
 state ss1 has entry function foo
 state ss1 has exit function bar
@@ -354,9 +378,11 @@ process_action_info: doNothing
 		add_to_action_array: state: s4
 	iterate_matrix_states: event: e3
 		add_to_action_array: state: s4
+	iterate_matrix_states: event: e4
+		add_to_action_array: state: s4
 populate_action_array returning false
 found a machine named newMachine
-	with 3 events and 4 states
+	with 4 events and 4 states
 Actions return events
 on transition: baz
 The states :
@@ -374,6 +400,8 @@ The events :
 	1:	e2
 
 	2:	e3
+
+	3:	e4 = BAR
 
 The actions :
 	a1
@@ -405,6 +433,7 @@ The actions :
 				e1
 				e2
 				e3
+				e4
 		and states
 				s4
 
@@ -424,12 +453,15 @@ this machine has data
 union {
 	struct {
 		int a;
-	} foo;
+	} * foo;
 	struct {
 		float f;
 	} beep;
-	int bop;
+	int ** bop;
 } u;
+float f[15];
+double d[];
+long l[NUM_LONGS];
 
 this machine has 2 sub-machines
 the sub-machine depth is 2

--- a/test/parser/parser-test30.fsm
+++ b/test/parser/parser-test30.fsm
@@ -1,0 +1,97 @@
+/*
+	Here are some comments
+*/
+native prologue
+{
+Copy this to the header file.
+DEFINE INIT_FSM_DATA {{0,0}, 1}
+}
+
+native epilogue
+{
+Copy this to the header file at the end.
+}
+
+machine newMachine
+ on transition baz;
+ native impl prologue { copy this to the source file; }
+ native impl epilogue { copy this to the source file at the end; }
+{
+data
+{
+
+ union
+ {
+  struct 
+  {
+  	int a;
+  } *foo;
+  
+  struct
+  {
+   float f;
+  } beep;
+ 
+  int  **bop;
+ } u;
+
+ float  f[15];
+ double d[];
+ long   l[NUM_LONGS];
+
+}
+
+	state s1, s2, s3, s4 inhibits submachines on entry;
+	event e1, e2, e3;
+  event e4 = BAR;
+
+
+	/** a sub machine */
+  machine subMachine1 {
+		state ss1 on entry foo on exit bar
+           , ss2 on entry on exit
+           , ss3 on entry foo1
+           , ss4 on exit bar1
+           ;
+		event ee1, ee2, ee3;
+
+		/** a sub-sub machine */
+		machine subSubMachine1 {
+			state z1, z2;
+			event y1, y2;
+
+			action x1[y1,z1];
+			action x2[y2, (all)] transition z1;
+		}
+
+		action aa1[ee1,ss1] transition ss2;
+		action aa2[ee2, ss1] transition ss3;
+	}
+
+	/** a second sub machine */
+  machine subMachine2 {
+		state sss1, sss2, sss3;
+		event eee1, eee2, eee3;
+
+		action aaa1[eee1,sss1] transition sss2;
+		action aaa2[eee2, sss1] transition sss3;
+	}
+
+	//This is a one-line comment
+	action a1[e1,s1] transition s1;
+
+	/**
+		A Document Comment
+	*/
+	action a2[e1,(s2,s3)] transition transitionFn;
+	transition[(e2,e3),(s1,s2,s3)] transitionFn1;
+
+	action doNothing[(all), s4];
+
+	transitionFn  returns s1,s2;
+	transitionFn1 returns s2,s3;
+
+	a2 returns noEvent;
+
+}
+

--- a/test/parser/parser-test4.canonical
+++ b/test/parser/parser-test4.canonical
@@ -1,20 +1,23 @@
 found simple data type id
-found data field: TYPE: simple; NAME: foo; dimension: none
+found data field: TYPE: simple; NAME: foo
 Starting data_fields list
 found simple data type id
-found data field: TYPE: simple; NAME: bar; dimension: none
+found data field: TYPE: simple; NAME: bar
 Continuing data_fields list
 found simple data type id
 found data field: TYPE: simple; NAME: baz; dimension: 256
 Continuing data_fields list
 found simple data type id
-found pointer data field: TYPE: simple; NAME: file1; dimension: none
+found pointer data type: TYPE: simple; indirection_level: 1
+found data field: TYPE: simple; NAME: file1
 Continuing data_fields list
 found simple data type name
-found pointer data field: TYPE: simple; NAME: file2; dimension: none
+found pointer data type: TYPE: simple; indirection_level: 1
+found data field: TYPE: simple; NAME: file2
 Continuing data_fields list
 found simple data type name
-found pointer data field: TYPE: simple; NAME: file3; dimension: none
+found pointer data type: TYPE: simple; indirection_level: 1
+found data field: TYPE: simple; NAME: file3
 Continuing data_fields list
 Data block done
 added another id to the event declaration list
@@ -90,12 +93,12 @@ The actions :
 
 The 0 transitions :
 this machine has data
-int  foo ;
-float  bar ;
-char  baz [256];
-FILE * file1 ;
-FILE * file2 ;
-FILE * file3 ;
+int foo;
+float bar;
+char baz[256];
+FILE * file1;
+FILE * file2;
+FILE * file3;
 
 
 found a single machine


### PR DESCRIPTION
closes #94

Added check for existence of INIT_FSM_DATA macro when machine has data.

Moved indirection and array dimension to the data type, where they belong.

Allow empty [] for array.