### PR TITLE
93 restructuredtext fsmlang output

### DIFF
--- a/linux/source.mk
+++ b/linux/source.mk
@@ -11,5 +11,6 @@ SRC =	lexer.c                \
 			cwalk.c             \
 			ancestry.c          \
 			fsm_statistics.c    \
-			fsm_c_event_xref.c
+			fsm_c_event_xref.c  \
+			fsm_rst.c
 

--- a/src/ancestry.c
+++ b/src/ancestry.c
@@ -44,48 +44,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-static char *create_string_from_file(FILE*,unsigned long*);
-
-/**
- * Creates a string comprising the contents of the provided
- * file.  The file is closed after reading.  Memory is
- * allocated, which must be freed by the caller.
- * 
- * @author Steven Stanton (2/10/2024)
- * 
- * @param file   FILE* pointer to the file containing the
- *  			 desrired string contents
- * 
- * @return char* pointer to the created string.
- */
-static char *create_string_from_file(FILE *file, unsigned long *str_len)
-{
-	char *cp = NULL;
-
-	if (file)
-	{
-		fseek(file, 0, SEEK_END);
-		const unsigned long file_size = ftell(file);
-
-		fseek(file, 0, SEEK_SET);
-
-		if ((cp = (char *) malloc(file_size + 1)) != NULL)
-		{
-			fread(cp, 1, file_size, file);
-			cp[file_size] = 0;
-		}
-
-		fclose(file);
-
-		if (str_len)
-		{
-			*str_len = file_size;
-		}
-	}
-
-	return cp;
-}
-
 char *createAncestryFileName(pMACHINE_INFO pmi)
 {
 	FILE *tmp = tmpfile();

--- a/src/fsm_priv.h
+++ b/src/fsm_priv.h
@@ -484,5 +484,7 @@ bool print_sub_machine_component_name(pLIST_ELEMENT,void*);
 bool print_sub_machine_events(pLIST_ELEMENT,void*);
 bool print_sub_machine_event_names(pLIST_ELEMENT,void*);
 bool print_data_field(pLIST_ELEMENT,void*);
+char *create_string_from_file(FILE*,unsigned long*);
+
 
 #endif /* ----------- nothing below this line ---------------- */

--- a/src/fsm_rst.c
+++ b/src/fsm_rst.c
@@ -1,0 +1,1031 @@
+/**
+*  fsm_rst.c
+*
+*    Output restructured text
+*
+*    FSMLang (fsm) - A Finite State Machine description language.
+*    Copyright (C) 2024  Steven Stanton
+*
+*    This program is free software; you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation; either version 2 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program; if not, write to the Free Software
+*    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*
+*    Steven Stanton
+*    fsmlang@pesticidesoftware.com
+*
+*    For the latest on FSMLang: https://fsmlang.github.io
+*
+*    And, finally, your possession of this source code implies nothing.
+*
+*    File created by Steven Stanton
+*
+*  Long Description:
+*
+*/
+
+#include "fsm_rst.h"
+
+#if defined (CYGWIN) || defined (LINUX)
+	#include <stdio.h>
+	#include <ctype.h>
+	#include <unistd.h>
+#endif
+#if defined (LINUX) || defined (VS) || defined (CYGWIN)
+	#include <time.h>
+#endif
+#include <string.h>
+#include <stdlib.h>
+
+//!< A must be pFSMRSTOutputGenerator
+#define FOUT(A) (A)->pmd->rstFile
+
+//!< A must be pFSMRSTOutputGenerator
+#define PMI(A) (A)->pmd->pmi
+
+//!< A must be pFSMRSTOutputGenerator
+#define PMD(A) (A)->pmd
+
+typedef struct _fsm_rst_output_generator_ FSMRSTOutputGenerator, *pFSMRSTOutputGenerator;
+typedef struct _rst_machine_data_ RSTMachineData, *pRSTMachineData;
+typedef struct _rst_iterator_helper_ RST_ITERATOR_HELPER, *pRST_ITERATOR_HELPER;
+
+static int initRSTWriter(pFSMOutputGenerator,char *);
+static void writeRSTWriter(pFSMOutputGenerator,pMACHINE_INFO);
+static void closeRSTWriter(pFSMOutputGenerator,int);
+
+static int initRSTFileNameWriter(pFSMOutputGenerator,char *);
+static void writeRSTFileName(pFSMOutputGenerator,pMACHINE_INFO);
+static void closeRSTFileNameWriter(pFSMOutputGenerator,int);
+
+static void print_toctree(pFSMRSTOutputGenerator);
+static bool print_sub_machine_toctree_entry(pLIST_ELEMENT,void*);
+static void print_actions(pFSMRSTOutputGenerator);
+static void print_states(pFSMRSTOutputGenerator);
+static void print_events(pFSMRSTOutputGenerator);
+static bool print_transition_fn_data(pLIST_ELEMENT,void*);
+static bool print_action_data(pLIST_ELEMENT,void*);
+static bool print_state_data(pLIST_ELEMENT,void*);
+static bool print_event_data(pLIST_ELEMENT,void*);
+static void print_id_info_data(pID_INFO,FILE*);
+static void print_state_chart(pFSMRSTOutputGenerator);
+static bool print_state_chart_event_header_row(pLIST_ELEMENT,void*);
+static bool print_state_chart_state_row(pLIST_ELEMENT,void*);
+static bool print_state_chart_state_row_event(pLIST_ELEMENT,void*);
+static void print_nchar(FILE*,char,size_t);
+static void print_reference_anchor(FILE*,char*,pRSTMachineData);
+static void print_machine_statistics(pFSMRSTOutputGenerator);
+static void print_transition_fns(pFSMRSTOutputGenerator);
+static void eat_spaces(FILE*,char*);
+static bool print_pid_as_reference_in_list(pLIST_ELEMENT,void*);
+static bool print_pid_in_list(pLIST_ELEMENT,void*);
+
+static char * fqMachineName(pRSTMachineData);
+
+struct _rst_machine_data_ {
+
+	FILE	      *rstFile;
+	char	      *rstName;
+    char          *baseName;
+	char          *fqmn;
+    pMACHINE_INFO pmi;
+};
+
+struct _fsm_rst_output_generator_
+{
+   FSMOutputGenerator fsmog;
+   pRSTMachineData   pmd;
+};
+
+struct _rst_iterator_helper_
+{
+	ITERATOR_HELPER        ih;
+	pFSMRSTOutputGenerator pfsmrstog;
+};
+
+static FSMRSTOutputGenerator RSTMachineWriter = {
+	{
+     initRSTWriter,
+     writeRSTWriter,
+     closeRSTWriter
+  },
+  NULL
+};
+
+static char *indent = "   ";
+
+pFSMOutputGenerator generateRSTMachineWriter(pFSMOutputGenerator parent)
+{
+	pFSMOutputGenerator pfsmog;
+
+	if (parent)
+	{
+		pFSMRSTOutputGenerator pfsmrstog = calloc(1, sizeof(FSMRSTOutputGenerator));
+
+		pfsmrstog->fsmog.writeMachine = writeRSTWriter;
+		pfsmrstog->fsmog.initOutput   = initRSTWriter;
+		pfsmrstog->fsmog.closeOutput  = closeRSTWriter;
+
+		pfsmog = (pFSMOutputGenerator)pfsmrstog;
+	}
+	else
+	{
+		pfsmog = (pFSMOutputGenerator)&RSTMachineWriter;
+	}
+
+	if (output_generated_file_names_only)
+	{
+		pfsmog->writeMachine = writeRSTFileName;
+		pfsmog->initOutput   = initRSTFileNameWriter;
+		pfsmog->closeOutput  = closeRSTFileNameWriter;
+	}
+
+	return pfsmog;
+}
+
+static int initRSTFileNameWriter (pFSMOutputGenerator pfsmog, char *baseFileName)
+{
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) pfsmog;
+	if (NULL != (pfsmrstog->pmd = calloc(1, sizeof(RSTMachineData))))
+	{
+		if (baseFileName)
+		{
+			pfsmrstog->pmd->rstName = createFileName(baseFileName,".rst");
+		}
+	}
+
+	/* this may look funny, but it does the trick */
+	return ((int) !pfsmrstog->pmd->rstName);
+}
+
+static void writeRSTFileName(pFSMOutputGenerator pfsmog, pMACHINE_INFO pmi)
+{
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator)pfsmog;
+
+	printf("%s ", pfsmrstog->pmd->rstName);
+
+	if (pmi->machine_list)
+	{
+		write_machines(pmi->machine_list, generateRSTMachineWriter, pfsmog);
+	}
+}
+
+static void closeRSTFileNameWriter(pFSMOutputGenerator pfsmog, int good)
+{
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) pfsmog;
+
+	(void) good;
+
+	if (!pfsmrstog || !pfsmrstog->pmd)
+	{
+		return;
+	}
+
+	CHECK_AND_FREE(pfsmrstog->pmd->rstName);
+
+	free(pfsmrstog->pmd);
+}
+
+static int initRSTWriter (pFSMOutputGenerator pfsmog, char *baseFileName)
+{
+
+  pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) pfsmog;
+
+  if (NULL != (pfsmrstog->pmd = calloc(1, sizeof(RSTMachineData))))
+  {
+     if (!baseFileName)
+     {
+
+       FOUT(pfsmrstog) = stdout;
+
+     }
+     else {
+
+       pfsmrstog->pmd->rstName = createFileName(baseFileName,".rst");
+       pfsmrstog->pmd->baseName = strdup(baseFileName);
+
+       if (!(FOUT(pfsmrstog) = openFile(pfsmrstog->pmd->rstName,"w"))) {
+
+         CHECK_AND_FREE(pfsmrstog->pmd->rstName);
+
+       }
+       else {
+
+         /* we're good to go; write the preamble */
+         fprintf(FOUT(pfsmrstog)
+				 ,"..\n%s%s\n\n"
+				 , indent
+				 ,pfsmrstog->pmd->rstName
+				 );
+         fprintf(FOUT(pfsmrstog)
+				 ,"%sThis file automatically generated by FSMLang\n\n"
+				 , indent
+				 );
+
+       }
+     }
+  }
+
+	/* this may look funny, but it does the trick */
+	return ((int) !FOUT(pfsmrstog));
+
+}
+
+static void writeRSTWriter(pFSMOutputGenerator pfsmog, pMACHINE_INFO pmi)
+{
+
+	RETURN_IF_NULL(pmi);
+
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator)pfsmog;
+
+	PMI(pfsmrstog) = pmi;
+
+	fprintf(FOUT(pfsmrstog)
+			, "\n%s\n"
+			, pmi->name->name
+			);
+
+	print_nchar(FOUT(pfsmrstog), '=', strlen(pmi->name->name) + 1);
+
+	if (pmi->name->docCmnt)
+	{
+		fprintf(FOUT(pfsmrstog), "\n\n");
+		eat_spaces(FOUT(pfsmrstog), pmi->name->docCmnt);
+		fprintf(FOUT(pfsmrstog), "\n\n");
+	}
+
+	fprintf(FOUT(pfsmrstog)
+			, "\n"
+			);
+
+	if (pmi->machine_list)
+	{
+		print_toctree(pfsmrstog);
+		write_machines(pmi->machine_list, generateRSTMachineWriter, pfsmog);
+	}
+
+	print_machine_statistics(pfsmrstog);
+
+	if (include_svg_img)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, ".. image:: %s.svg\n%s:alt: PlantUML diagram separately generated.\n\n"
+				, pfsmrstog->pmd->baseName
+				, indent
+			   );
+	}
+
+
+	print_state_chart(pfsmrstog);
+	print_events(pfsmrstog);
+	print_states(pfsmrstog);
+	print_actions(pfsmrstog);
+
+	if (pmi->transition_fn_list->count)
+	{
+		print_transition_fns(pfsmrstog);
+	}
+
+
+}
+
+static void closeRSTWriter(pFSMOutputGenerator pfsmog, int good)
+{
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) pfsmog;
+
+	if (!pfsmrstog || !pfsmrstog->pmd)
+	{
+		return;
+	}
+
+	fclose(FOUT(pfsmrstog));
+
+	if (!good)
+	{
+		unlink(pfsmrstog->pmd->rstName);
+	}
+
+	CHECK_AND_FREE(pfsmrstog->pmd->rstName);
+
+	free(pfsmrstog->pmd);
+}
+
+static void print_toctree(pFSMRSTOutputGenerator pfsmrstog)
+{
+	fprintf(FOUT(pfsmrstog)
+			, "\n\n.. toctree::\n%s:hidden:\n%s:maxdepth: 2\n\n"
+			, indent
+			, indent
+			);
+
+	iterate_list(PMI(pfsmrstog)->machine_list
+				 , print_sub_machine_toctree_entry
+				 , pfsmrstog
+				 );
+}
+
+static bool print_sub_machine_toctree_entry(pLIST_ELEMENT pelem, void *data)
+{
+	pMACHINE_INFO          pmi       = (pMACHINE_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s%s\n"
+			, indent
+			, pmi->name->name
+			);
+
+	return false;
+}
+
+
+static void print_actions(pFSMRSTOutputGenerator pfsmrstog)
+{
+	fprintf(FOUT(pfsmrstog)
+			, "\n\nActions\n--------\n"
+			);
+
+	iterate_list(PMI(pfsmrstog)->action_list
+				 , print_action_data
+				 , pfsmrstog
+				 );
+}
+
+static void print_states(pFSMRSTOutputGenerator pfsmrstog)
+{
+	fprintf(FOUT(pfsmrstog)
+			, "\n\nStates\n-------\n"
+			);
+
+	iterate_list(PMI(pfsmrstog)->state_list
+				 , print_state_data
+				 , pfsmrstog
+				 );
+}
+
+static void print_events(pFSMRSTOutputGenerator pfsmrstog)
+{
+	fprintf(FOUT(pfsmrstog)
+			, "\n\nEvents\n-------\n"
+			);
+
+	iterate_list(PMI(pfsmrstog)->event_list
+				 , print_event_data
+				 , pfsmrstog
+				 );
+}
+
+static void print_transition_fns(pFSMRSTOutputGenerator pfsmrstog)
+{
+	fprintf(FOUT(pfsmrstog)
+			, "\n\nTransition Functions\n---------------------\n"
+			);
+
+	iterate_list(PMI(pfsmrstog)->transition_fn_list
+				 , print_transition_fn_data
+				 , pfsmrstog
+				 );
+}
+
+static void print_id_info_data(pID_INFO pid, FILE *fout)
+{
+	if (strlen(pid->name))
+	{
+		fprintf(fout
+				, "\n%s\n"
+				, pid->name
+				);
+
+		print_nchar(fout, '~', strlen(pid->name) + 1);
+
+		if (pid->docCmnt)
+		{
+			fprintf(fout, "\n\n");
+			eat_spaces(fout, pid->docCmnt);
+			fprintf(fout, "\n\n");
+		}
+	}
+}
+
+static bool print_transition_fn_data(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               ptransition_fn   = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+
+	print_reference_anchor(FOUT(pfsmrstog)
+						   , ptransition_fn->name
+						   , PMD(pfsmrstog)
+						   );
+
+	print_id_info_data(ptransition_fn, FOUT(pfsmrstog));
+
+	return false;
+}
+
+static bool print_action_data(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               paction   = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+	pACTION_DATA           pdata     = &paction->type_data.action_data;
+
+	print_reference_anchor(FOUT(pfsmrstog), paction->name, PMD(pfsmrstog));
+
+	print_id_info_data(paction, FOUT(pfsmrstog));
+
+	if (pdata->action_returns_decl)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis action returns:\n\n"
+				);
+
+		iterate_list(pdata->action_returns_decl
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+
+		fprintf(FOUT(pfsmrstog), "\n");
+	}
+
+	return false;
+}
+
+static bool print_state_data(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               pstate    = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+	pSTATE_DATA            pdata     = &pstate->type_data.state_data;
+
+	print_reference_anchor(FOUT(pfsmrstog), pstate->name, PMD(pfsmrstog));
+
+	print_id_info_data(pstate, FOUT(pfsmrstog));
+
+	if (pdata->state_flags & sfInibitSubMachines)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis state prohibits sub machines from running.\n\n"
+				);
+
+	}
+
+	if (pdata->entry_fn)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\n%s is called on entry.\n\n"
+				, pdata->entry_fn->name
+				);
+	}
+
+	if (pdata->exit_fn)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\n%s is called on exit.\n\n"
+				, pdata->exit_fn->name
+				);
+	}
+
+	if (pdata->pevents_handled->count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThese events are handled in this state:\n\n"
+				);
+
+		iterate_list(pdata->pevents_handled
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis yields an event density of %u%%.\n\n"
+				, pdata->event_density_pct
+				);
+
+	}
+	else
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\n.. attention::\n\n   This state handles no events.\n\n"
+				);
+
+	}
+
+	if (pdata->pactions_list->count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThese actions are taken in this state:\n\n"
+				);
+
+		iterate_list(pdata->pactions_list
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+
+	}
+	else
+	{
+		if (pdata->pevents_handled->count)
+		{
+			fprintf(FOUT(pfsmrstog)
+					, "\n\n.. warning:\n\n   No actions are taken in this state.\n\n"
+				   );
+		}
+
+	}
+
+	if (pdata->pinbound_transitions->count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThese states transition into this state:\n\n"
+				);
+
+		iterate_list(pdata->pinbound_transitions
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+
+	}
+	else
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\n.. warning::\n\n   There is no way into this state.\n\n"
+				);
+
+	}
+
+	if (pdata->poutbound_transitions->count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis state transitions into these states:\n\n"
+				);
+
+		iterate_list(pdata->poutbound_transitions
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+
+	}
+	else
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\n.. warning::\n\n   There is no way out of this state.\n\n"
+				);
+	}
+
+
+	return false;
+}
+
+static bool print_event_data(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               pevent    = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+	pEVENT_DATA            pdata     = &pevent->type_data.event_data;
+
+	print_reference_anchor(FOUT(pfsmrstog), pevent->name, PMD(pfsmrstog));
+
+	print_id_info_data(pevent, FOUT(pfsmrstog));
+
+	if (pdata->shared_with_parent)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis event is shared from the parent machine.\n\n"
+				);
+
+	}
+
+	if (pdata->single_pai_for_all_states)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis event is handled identically in all states.\n\n"
+				);
+
+	}
+	else if (pdata->single_pai_state_count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis event is handled identically in %u states.\n\n"
+				, pdata->single_pai_state_count
+				);
+
+	}
+
+	if (pdata->externalDesignation)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThe enumeration value of this event is defined externally as %s.\n\n"
+				, pdata->externalDesignation->name
+				);
+
+	}
+
+	if (pdata->psharing_sub_machines)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "These sub-machines share this event:\n\n"
+				);
+
+		iterate_list(pdata->psharing_sub_machines
+					 , print_pid_in_list
+					 , pfsmrstog
+					 );
+
+	}
+
+	if (pdata->phandling_states->count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThese states handle this event:\n\n"
+				);
+
+		iterate_list(pdata->phandling_states
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThis yields a state density of %u%%.\n\n"
+				, pdata->state_density_pct
+				);
+
+	}
+	else
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\n.. warning::\n\n   This event is handled in no state.\n\n"
+				);
+
+	}
+
+	if (pdata->pactions_list->count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "\n\nThese actions are taken in response to this event:\n\n"
+				);
+
+		iterate_list(pdata->pactions_list
+					 , print_pid_as_reference_in_list
+					 , pfsmrstog
+					 );
+	}
+	else
+	{
+		if (pdata->phandling_states->count)
+		{
+			fprintf(FOUT(pfsmrstog)
+					, "\n\nNo actions are taken in response to this event.\n\n"
+				   );
+		}
+
+	}
+
+	return false;
+}
+
+static void print_state_chart(pFSMRSTOutputGenerator pfsmrstog)
+{
+	fprintf(FOUT(pfsmrstog)
+			, "\n.. list-table:: State Chart\n%s:align: left\n%s:header-rows: 1\n%s:stub-columns: 1\n"
+			, indent
+			, indent
+			, indent
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "\n%s* -\n"
+			, indent
+			);
+
+	iterate_list(PMI(pfsmrstog)->event_list
+				 , print_state_chart_event_header_row
+				 , pfsmrstog
+				 );
+
+
+	iterate_list(PMI(pfsmrstog)->state_list
+				 , print_state_chart_state_row
+				 , pfsmrstog
+				 );
+
+
+}
+
+static bool print_state_chart_event_header_row(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               pevent    = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s  - :ref:`%s <%s.%s>`\n"
+			, indent
+			, pevent->name
+			, fqMachineName(pfsmrstog->pmd)
+			, pevent->name
+			);
+
+	return false;
+}
+
+char *fqMachineName(pRSTMachineData pcmd)
+{
+	FILE          *tmp;
+
+	if (!pcmd->fqmn)
+	{
+		/* use a temporary file to exploit streaming function, avoiding messy strlen calc */
+		if (NULL != (tmp = tmpfile()))
+		{
+			printAncestry(pcmd->pmi, tmp, ".", alc_lower, ai_include_self);
+
+			pcmd->fqmn = create_string_from_file(tmp, NULL);
+
+		}
+	}
+
+	return pcmd->fqmn;
+}
+
+static bool print_state_chart_state_row(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               pstate    = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+
+	RST_ITERATOR_HELPER    rstih = {
+		.ih = {
+			.state = pelem->ordinal
+		}
+		, .pfsmrstog = pfsmrstog
+	};
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - :ref:`%s <%s.%s>`\n"
+			, indent
+			, pstate->name
+			, fqMachineName(PMD(pfsmrstog))
+			, pstate->name
+			);
+
+	iterate_list(PMI(pfsmrstog)->event_list
+				 , print_state_chart_state_row_event
+				 , &rstih
+				 );
+
+	return false;
+}
+
+static bool print_state_chart_state_row_event(pLIST_ELEMENT pelem, void *data)
+{
+	pRST_ITERATOR_HELPER prstih = (pRST_ITERATOR_HELPER) data;
+	pACTION_INFO         pai    = PMI(prstih->pfsmrstog)->actionArray[pelem->ordinal][prstih->ih.state];
+
+	fprintf(FOUT(prstih->pfsmrstog)
+			, "%s  - "
+			, indent
+			);
+
+	if (pai)
+	{
+		if (strlen(pai->action->name))
+		{
+			fprintf(FOUT(prstih->pfsmrstog)
+					, "%s:ref:`%s <%s.%s>`\n"
+					, pai->transition ? "| " : ""
+					, pai->action->name
+					, fqMachineName(PMD(prstih->pfsmrstog))
+					, pai->action->name
+					);
+		}
+
+		if (pai->transition)
+		{
+			fprintf(FOUT(prstih->pfsmrstog)
+					, "%stransition: :ref:`%s <%s.%s>`\n"
+					, strlen(pai->action->name) ? "       | " : ""
+					, pai->transition->name
+					, fqMachineName(PMD(prstih->pfsmrstog))
+					, pai->transition->name
+					);
+		}
+	}
+	else
+	{
+		fprintf(FOUT(prstih->pfsmrstog), "\n");
+	}
+
+	return false;
+}
+
+static void print_nchar(FILE *fout, char to_print, size_t how_many)
+{
+	while (how_many--)
+	{
+		fputc(to_print, fout);
+	}
+}
+
+static void print_reference_anchor(FILE *fout, char *name, pRSTMachineData pmd)
+{
+	if (strlen(name))
+	{
+		fprintf(fout
+				, "\n\n.. _%s.%s:\n"
+				, fqMachineName(pmd)
+				, name
+				);
+	}
+}
+
+static void print_machine_statistics(pFSMRSTOutputGenerator pfsmrstog)
+{
+
+	fprintf(FOUT(pfsmrstog)
+			, "\n.. list-table:: Machine Statistics\n%s:align: left\n\n"
+			, indent
+			);
+
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - Number of events:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->event_list->count
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - Events not handled:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->events_with_zero_handlers
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - Events handled in one state:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->events_with_one_handler
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - At least one event handled the same in all states?\n%s  - %s\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->has_single_pai_events ? "yes" : "no"
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - Number of states:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->state_list->count
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - Number of states with entry functions:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->states_with_exit_fns_count
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - Number of states with exit functions:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->states_with_exit_fns_count
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - States handling no events:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->states_with_zero_events
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - States handling exactly one event:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->states_with_one_event
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - States with no way in:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->states_with_no_way_in
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "%s* - States with no way out:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->states_with_no_way_out
+			);
+
+	fprintf(FOUT(pfsmrstog)
+			, "\n\n"
+			);
+
+
+}
+
+static void eat_spaces(FILE *fout, char *str)
+{
+	enum {printing, skipping, check_para} state = skipping;
+	unsigned line_width = 0;
+	for (char *cp = str; *cp; cp++)
+	{
+		switch (state)
+		{
+		case skipping:
+
+			if ((*cp != ' ') && (*cp != '\n') && (*cp != '\t'))
+			{
+				fputc(*cp, fout);
+				line_width++;
+				state = printing;
+			}
+
+			break;
+
+		case printing:
+			fputc(*cp, fout);
+			line_width++;
+
+			if ((*cp == ' ') || (*cp == '\n'))
+			{
+				if (line_width > 75)
+				{
+					if (*cp != '\n')
+					{
+						fputc('\n', fout);
+					}
+					line_width = 0;
+				}
+				state = *cp == ' ' ? skipping : check_para;
+			}
+			break;
+
+		case check_para:
+
+			if ((*cp == '\n') || ((*cp != ' ') && (*cp != '\t')))
+			{
+				fputc(*cp, fout);
+			}
+			state = skipping;
+			break;
+
+		}
+	}
+}
+
+static bool print_pid_as_reference_in_list(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               pid       = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+
+	bool no_reference = strstr(pid->name, "noEvent")
+	                    || strstr(pid->name, "noTransition")
+	                    ;
+
+	if (no_reference)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "* %s\n"
+				, pid->name
+				);
+	}
+	else
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "* :ref:`%s <%s.%s>`\n"
+				, pid->name
+				, fqMachineName(PMD(pfsmrstog))
+				, pid->name
+				);
+	}
+
+	return false;
+}
+
+
+static bool print_pid_in_list(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO               pid       = (pID_INFO) pelem->mbr;
+	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
+
+	                    ;
+	fprintf(FOUT(pfsmrstog)
+			, "* %s\n"
+			, pid->name
+			);
+
+	return false;
+}
+

--- a/src/fsm_rst.c
+++ b/src/fsm_rst.c
@@ -87,7 +87,6 @@ static void print_machine_statistics(pFSMRSTOutputGenerator);
 static void print_transition_fns(pFSMRSTOutputGenerator);
 static void eat_spaces(FILE*,char*);
 static bool print_pid_as_reference_in_list(pLIST_ELEMENT,void*);
-static bool print_pid_in_list(pLIST_ELEMENT,void*);
 static bool print_pmi_in_list(pLIST_ELEMENT,void*);
 
 static char * fqMachineName(pRSTMachineData);
@@ -1064,20 +1063,6 @@ static bool print_pid_as_reference_in_list(pLIST_ELEMENT pelem, void *data)
 	return false;
 }
 
-
-static bool print_pid_in_list(pLIST_ELEMENT pelem, void *data)
-{
-	pID_INFO               pid       = (pID_INFO) pelem->mbr;
-	pFSMRSTOutputGenerator pfsmrstog = (pFSMRSTOutputGenerator) data;
-
-	                    ;
-	fprintf(FOUT(pfsmrstog)
-			, "* %s\n"
-			, pid->name
-			);
-
-	return false;
-}
 
 static bool print_pmi_in_list(pLIST_ELEMENT pelem, void *data)
 {

--- a/src/fsm_rst.c
+++ b/src/fsm_rst.c
@@ -249,12 +249,16 @@ static void writeRSTWriter(pFSMOutputGenerator pfsmog, pMACHINE_INFO pmi)
 
 	PMI(pfsmrstog) = pmi;
 
+	int title_decoration_len = strlen(pmi->name->name) + 1;
+
+	print_nchar(FOUT(pfsmrstog), '=', title_decoration_len);
+
 	fprintf(FOUT(pfsmrstog)
 			, "\n%s\n"
 			, pmi->name->name
 			);
 
-	print_nchar(FOUT(pfsmrstog), '=', strlen(pmi->name->name) + 1);
+	print_nchar(FOUT(pfsmrstog), '=', title_decoration_len);
 
 	if (pmi->name->docCmnt)
 	{

--- a/src/fsm_rst.h
+++ b/src/fsm_rst.h
@@ -1,0 +1,44 @@
+/**
+*  fsm_rst.h
+*
+*    Output restructured text
+*
+*    FSMLang (fsm) - A Finite State Machine description language.
+*    Copyright (C) 2024  Steven Stanton
+*
+*    This program is free software; you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation; either version 2 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program; if not, write to the Free Software
+*    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*
+*    Steven Stanton
+*    fsmlang@pesticidesoftware.com
+*
+*    For the latest on FSMLang: https://fsmlang.github.io
+*
+*    And, finally, your possession of this source code implies nothing.
+*
+*    File created by Steven Stanton
+*
+*  Long Description:
+*
+*/
+
+#ifndef FSM_RST_H
+#define FSM_RST_H
+
+#include "fsm_priv.h"
+
+pFSMOutputGenerator generateRSTMachineWriter(pFSMOutputGenerator);
+
+#endif
+

--- a/src/fsm_utils.c
+++ b/src/fsm_utils.c
@@ -1490,6 +1490,46 @@ static bool add_inbound_state_wrapper(pLIST_ELEMENT pelem, void *data)
 	return false;
 }
 
+/**
+ * Creates a string comprising the contents of the provided
+ * file.  The file is closed after reading.  Memory is
+ * allocated, which must be freed by the caller.
+ * 
+ * @author Steven Stanton (2/10/2024)
+ * 
+ * @param file   FILE* pointer to the file containing the
+ *  			 desrired string contents
+ * 
+ * @return char* pointer to the created string.
+ */
+char *create_string_from_file(FILE *file, unsigned long *str_len)
+{
+	char *cp = NULL;
+
+	if (file)
+	{
+		fseek(file, 0, SEEK_END);
+		const unsigned long file_size = ftell(file);
+
+		fseek(file, 0, SEEK_SET);
+
+		if ((cp = (char *) malloc(file_size + 1)) != NULL)
+		{
+			fread(cp, 1, file_size, file);
+			cp[file_size] = 0;
+		}
+
+		fclose(file);
+
+		if (str_len)
+		{
+			*str_len = file_size;
+		}
+	}
+
+	return cp;
+}
+
 #ifdef PARSER_DEBUG
 
 typedef struct _debug_list_helper_ DEBUG_LIST_HELPER, *pDEBUG_LIST_HELPER;

--- a/src/parser.y
+++ b/src/parser.y
@@ -31,6 +31,7 @@
 #include "fsm_plantuml.h"
 #include "fsm_statistics.h"
 #include "fsm_c_event_xref.h"
+#include "fsm_rst.h"
 
 #include "list.h"
 
@@ -2216,7 +2217,7 @@ const struct option longopts[] =
     }
     , {
         .name      = "include-svg-img"
-        , .has_arg = required_argument
+        , .has_arg = optional_argument
         , .flag    = &longval
         , .val     = lo_include_svg_img
     }
@@ -2368,8 +2369,10 @@ int main(int argc, char **argv)
                     = !strcmp(optarg,"true") ? true : false;
                 break;
             case lo_include_svg_img:
-                include_svg_img
-                    = !strcmp(optarg,"true") ? true : false;
+                if (!optarg || !strcmp(optarg, "true"))
+                {
+                  include_svg_img = true;
+                }
                 break;
             case lo_css_content_filename:
                 css_content_filename = optarg;
@@ -2518,6 +2521,10 @@ int main(int argc, char **argv)
 					case 'p':
 						fpfsmogf = generatePlantUMLMachineWriter;
 						break;
+
+          case 'r':
+            fpfsmogf = generateRSTMachineWriter;
+            break;
 
 					default:
 						usage();
@@ -2676,11 +2683,12 @@ void yyerror(char *s)
 void usage(void)
 {
 
-	fprintf(stdout,"Usage : %s [-tc|s|h|p] [-o outfile] [-s] filename, where filename ends with '.fsm'\n",me);
+	fprintf(stdout,"Usage : %s [-tc|s|h|p|r] [-o outfile] [-s] filename, where filename ends with '.fsm'\n",me);
 	fprintf(stdout,"\t and where 'c' gets you c code output based on an event/state table,\n");
 	fprintf(stdout,"\t 's' gets you c code output with individual state functions using switch constructions,\n");
 	fprintf(stdout,"\t and 'h' gets you html output\n");
 	fprintf(stdout,"\t and 'p' gets you PlantUML output\n");
+	fprintf(stdout,"\t and 'p' gets you reStructuredText output\n");
 	fprintf(stdout,"\t-i0 inhibits the creation of a machine instance\n");
 	fprintf(stdout,"\t\tany other argument to 'i' allows the creation of an instance;\n");
 	fprintf(stdout,"\t\tthis is the default\n");
@@ -2697,7 +2705,7 @@ void usage(void)
 	fprintf(stdout,"\t--core-logging-only=true suppresses the generation of debug log messages in all but the core FSM function.\n");
  fprintf(stdout,"\t--generate-run-function<=true|false> this option is deprecated.  The run function is always generated;\n");
 	fprintf(stdout,"\t\tno RUN_STATE_MACHINE macro is provided.\n");
-	fprintf(stdout,"\t--include-svg-img=true adds <img/> tag referencing <filename>.svg to include an image at\n");
+	fprintf(stdout,"\t--include-svg-img<=*true|false> adds <img/> tag referencing <filename>.svg to include an image at\n");
   fprintf(stdout,"\t\tthe top of the web page.\n");
 	fprintf(stdout,"\t--css-content-internal=true puts the CSS directly into the html.\n");
 	fprintf(stdout,"\t--css-content-filename=<filename> uses the named file for the css citation, or\n");

--- a/test/unit/misc_cl_options/Makefile
+++ b/test/unit/misc_cl_options/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: test_file_listers test_m_c test_m_s test_md_c test_md_s test_mh_c test_mh_s test_file_creators
+.PHONY: test_file_listers test_file_creators $(LISTERS)
 
 test_m_c: FSM_FLAGS=-M -tc
 test_m_s: FSM_FLAGS=-M -ts
@@ -9,10 +9,30 @@ test_mh_c: FSM_FLAGS=-Mh -tc
 test_mh_s: FSM_FLAGS=-Mh -ts
 test_m_p: FSM_FLAGS=-M -tp
 test_m_h: FSM_FLAGS=-M -th
+test_m_r: FSM_FLAGS=-M -tr
+test_m_r_o: FSM_FLAGS=-M -tr -o index
 test.json: FSM_FLAGS=--event-cross-ref-only=true
 test.xml: FSM_FLAGS=--event-cross-ref-format=xml
 test.tab: FSM_FLAGS=--event-cross-ref-format=tab
 test.csv: FSM_FLAGS=--event-cross-ref-format=csv
+
+LISTERS = \
+        test_m_c \
+        test_m_s \
+        test_md_c \
+        test_md_s \
+        test_mh_c \
+        test_mh_s \
+        test_m_p \
+        test_m_h \
+        test_m_r \
+        test_m_r_o 
+
+CREATORS = \
+         test.json \
+         test.xml  \
+         test.tab  \
+         test.csv
 
 FSM=$(OUTPUT_DIR)/fsm
 
@@ -22,15 +42,15 @@ test_file_creators: test.json test.xml test.tab
 	@rm $?
 	@rm -f *.result
 
-test_file_listers: test_m_c test_m_s test_md_c test_md_s test_mh_c test_mh_s test_m_p test_m_h
+test_file_listers: $(LISTERS)
 	@rm -f *.out
 	@rm -f *.result
 
-test_m_c test_m_s test_md_c test_md_s test_mh_c test_mh_s test_m_p test_m_h test_xref_json: $(FSM) Makefile
+$(LISTERS): $(FSM) Makefile
 	$(FSM) $(FSM_FLAGS) test.fsm > $@.out
 	@diff $@.out $@.canonical > $@.result
 
-test.json test.xml test.tab test.csv: $(FSM) Makefile
+$(CREATORS): $(FSM) Makefile
 	$(FSM) $(FSM_FLAGS) test.fsm 
 	@diff $@ $@.canonical > $@.result
 

--- a/test/unit/misc_cl_options/test_m_r.canonical
+++ b/test/unit/misc_cl_options/test_m_r.canonical
@@ -1,0 +1,1 @@
+test.rst sub1.rst sub2.rst sub2Sub1.rst 

--- a/test/unit/misc_cl_options/test_m_r_o.canonical
+++ b/test/unit/misc_cl_options/test_m_r_o.canonical
@@ -1,0 +1,1 @@
+index.rst sub1.rst sub2.rst sub2Sub1.rst 


### PR DESCRIPTION
Basic restructured text and sphinx features are used in reStructuredText files to represent state machines.

The svg version of the bubble diagram can be optionally included.

if -o index is given, the top-level machine will be placed in index.rst; otherwise standard file naming will be used.

The .rst files are placed in the current directory, regardless of whether -o index is used or not.