### PR TITLE
Added check for first state when looking to apply the 'stateWithNoEnt…

### DIFF
--- a/fsmlang.css
+++ b/fsmlang.css
@@ -77,6 +77,7 @@
 	border-width   : .5px;
 	border-color   : black;
 	width          : 75%;
+	padding        : 20px;
 }
 
 .elements th {
@@ -84,14 +85,14 @@
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements td {
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements .summary tr, th, td {

--- a/src/fsm_html.c
+++ b/src/fsm_html.c
@@ -754,7 +754,8 @@ static bool print_state_table_state_row(pLIST_ELEMENT pelem, void *data)
 	fprintf(pih->fout
 			,"<td class='label%s%s%s'>%s</td>\n<td>\n"
 			, psd->pevents_handled->count == 0       ? " lazyState"        : ""
-			, psd->pinbound_transitions->count == 0  ? " stateWithNoEntry" : ""
+			, ((psd->pinbound_transitions->count == 0) && (pelem->ordinal != 0))
+			    ? " stateWithNoEntry" : ""
 			, psd->poutbound_transitions->count == 0 ? " deadEndState"     : ""
 			, pstate->name
 			);

--- a/test/full_test68/anotherSubMachine1.html.canonical
+++ b/test/full_test68/anotherSubMachine1.html.canonical
@@ -146,7 +146,7 @@
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>ss1</td>
+<td class='label'>ss1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>

--- a/test/full_test68/anotherSubMachine2.html.canonical
+++ b/test/full_test68/anotherSubMachine2.html.canonical
@@ -127,7 +127,7 @@
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>sss1</td>
+<td class='label'>sss1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>

--- a/test/full_test68/anotherSubSubMachine1.html.canonical
+++ b/test/full_test68/anotherSubSubMachine1.html.canonical
@@ -129,7 +129,7 @@
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>z1</td>
+<td class='label'>z1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>

--- a/test/full_test68/subMachine1.html.canonical
+++ b/test/full_test68/subMachine1.html.canonical
@@ -127,7 +127,7 @@
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>ss1</td>
+<td class='label'>ss1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>

--- a/test/full_test68/subMachine2.html.canonical
+++ b/test/full_test68/subMachine2.html.canonical
@@ -127,7 +127,7 @@
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>sss1</td>
+<td class='label'>sss1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>

--- a/test/full_test68/subSubMachine1.html.canonical
+++ b/test/full_test68/subSubMachine1.html.canonical
@@ -113,7 +113,7 @@
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>z1</td>
+<td class='label'>z1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>

--- a/test/html/test1/test1.html.canonical
+++ b/test/html/test1/test1.html.canonical
@@ -89,6 +89,7 @@
 	border-width   : .5px;
 	border-color   : black;
 	width          : 75%;
+	padding        : 20px;
 }
 
 .elements th {
@@ -96,14 +97,14 @@
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements td {
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements .summary tr, th, td {

--- a/test/html/test1/test2.html.canonical
+++ b/test/html/test1/test2.html.canonical
@@ -89,6 +89,7 @@
 	border-width   : .5px;
 	border-color   : black;
 	width          : 75%;
+	padding        : 20px;
 }
 
 .elements th {
@@ -96,14 +97,14 @@
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements td {
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements .summary tr, th, td {
@@ -358,7 +359,7 @@ code {
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>s1</td>
+<td class='label'>s1</td>
 <td>
 <p> A state to begin with. </p>
 <p>Outbound Transitions:</p>

--- a/test/html/test1/test3.html.canonical
+++ b/test/html/test1/test3.html.canonical
@@ -89,6 +89,7 @@
 	border-width   : .5px;
 	border-color   : black;
 	width          : 75%;
+	padding        : 20px;
 }
 
 .elements th {
@@ -96,14 +97,14 @@
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements td {
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements .summary tr, th, td {
@@ -363,7 +364,7 @@ code {
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>s1</td>
+<td class='label'>s1</td>
 <td>
 <p> A state to begin with. </p>
 <p>Outbound Transitions:</p>

--- a/test/html/test1/test4.html.canonical
+++ b/test/html/test1/test4.html.canonical
@@ -89,6 +89,7 @@
 	border-width   : .5px;
 	border-color   : black;
 	width          : 75%;
+	padding        : 20px;
 }
 
 .elements th {
@@ -96,14 +97,14 @@
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements td {
 	border-style: solid;
 	border-width: .5px;
 	border-color: black;
-	padding: 3px;
+	padding: 20px;
 }
 
 .elements .summary tr, th, td {
@@ -347,7 +348,7 @@ code {
 	</td>
 </tr>
 <tr>
-<td class='label stateWithNoEntry'>s1</td>
+<td class='label'>s1</td>
 <td>
 <p>Outbound Transitions:</p>
 	<ul>


### PR DESCRIPTION
…ry' class to a td element.

The fprintf adding the "stateWithNoWayIn" class to the td element was not checking whether the state in question was the first state.

Updated relevant html tests.