### PR TITLE
Added missing newline before 'end note' in case where exactly one loo…

### DIFF
--- a/src/fsm_plantuml.c
+++ b/src/fsm_plantuml.c
@@ -682,7 +682,7 @@ static void writePlantUMLWriter(pFSMOutputGenerator pfsmog, pMACHINE_INFO pmi)
          if (pai->docCmnt)
          {
             fprintf(pfsmpumlog->pmd->pumlFile
-                    , "\nnote on link\n%send note\n"
+                    , "\nnote on link\n%s\nend note\n"
                     , pai->docCmnt
                    );
          }


### PR DESCRIPTION
…pback event is present.

That pretty much says it.