### PR TITLE
Pass OUTPUT_DIR to subordiate Makefiles during cleans.

### DIFF
--- a/cygwin/Makefile
+++ b/cygwin/Makefile
@@ -27,7 +27,7 @@ clean::
 	-@rm -f *.output            2> /dev/nul
 
 test: 
-	$(MAKE) -C ../test clean
+	$(MAKE) OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test clean
 	$(MAKE) CFLAGS="-DCYGWIN" OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test all
 
 testonly:

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -29,7 +29,7 @@ clean::
 	-@rm -f y.output            2> /dev/null
 
 test: 
-	$(MAKE) -C ../test clean
+	$(MAKE) OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test clean
 	$(MAKE) ARCH="$(ARCH)" OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test all
 
 testonly:

--- a/mingw/Makefile
+++ b/mingw/Makefile
@@ -27,7 +27,7 @@ clean::
 	-@rm -f y.output            2> /dev/nul
 
 test: 
-	$(MAKE) -C ../test clean
+	$(MAKE) OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test clean
 	$(MAKE) CFLAGS="-DCYGWIN -DMINGW" OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test all
 
 testonly: 

--- a/mingwsa/Makefile
+++ b/mingwsa/Makefile
@@ -27,7 +27,7 @@ clean::
 
 test: 
 	@echo mingwsa/Makefile: OUTPUT_DIR: $(OUTPUT_DIR)
-	$(MAKE) -C ../test clean
+	$(MAKE) OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test clean
 	$(MAKE) CFLAGS="-DCYGWIN -DMINGW" OUTPUT_DIR="$(OUTPUT_DIR)" -C ../test all
 
 testonly: 

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ $(ARCHITECTURES):
 	$(MAKE) CFLAGS="$(CFLAGS)" -C $(OUT_DIR) fsm
 
 $(addsuffix .clean, $(ARCHITECTURES)):
-	$(MAKE) -j -C ../test clean
+	$(MAKE) -j -C ../test OUTPUT_DIR="$(shell pwd)/$(OUT_DIR)" clean
 	$(MAKE) -j -C $(OUT_DIR) clean
 
 $(addsuffix .test, $(ARCHITECTURES)): $$(basename $$@)

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ $(SUITES):
 	$(MAKE) -C $@ CFLAGS="$(CFLAGS)" ARCH="$(ARCH)" OUTPUT_DIR="$(OUTPUT_DIR)" runtest
 
 $(CLEAN_SUITES):
-	$(MAKE) -C $(basename $@) clean
+	$(MAKE) -C $(basename $@) OUTPUT_DIR="$(OUTPUT_DIR)" clean
 
 check:
 	@echo $(SUITES)

--- a/test/html/Makefile
+++ b/test/html/Makefile
@@ -17,7 +17,7 @@ $(SUITES):
 	$(MAKE) -C $@ OUTPUT_DIR="$(OUTPUT_DIR)" runtest
 
 $(CLEAN_SUITES):
-	$(MAKE) -C $(basename $@) clean
+	$(MAKE) -C $(basename $@) OUTPUT_DIR="$(OUTPUT_DIR)" clean
 
 check:
 	@echo $(SUITES)

--- a/test/lexer/Makefile
+++ b/test/lexer/Makefile
@@ -4,9 +4,10 @@
 #
 #
 
-ifdef OUTPUT_DIR
-include $(OUTPUT_DIR)/system.mk
+ifndef OUTPUT_DIR
+$(error OUTPUT_DIR must be defined as the location of the created executable.)
 endif
+include $(OUTPUT_DIR)/system.mk
 
 VPATH=../../src
 

--- a/test/test.mk
+++ b/test/test.mk
@@ -8,11 +8,13 @@
 override CFLAGS += -Wall -Wpedantic -Wextra -I../
 
 
-ifdef OUTPUT_DIR
-include $(OUTPUT_DIR)/system.mk
+ifndef OUTPUT_DIR
+$(error OUTPUT_DIR must be set to the location of the built executable)
 endif
 
+include $(OUTPUT_DIR)/system.mk
 include $(OUTPUT_DIR)/../depends.mk
+
 
 POSSIBLE_OBJS = $(SRC:.c=.o) $(FSM_SRC:.fsm=.o) $(GENERATED_SRC:.c=.o)
 OBJS = $(sort $(POSSIBLE_OBJS))


### PR DESCRIPTION
The title says it all.

OUTPUT_DIR is used to find included makefiles; it was not being passed to nested calls of make in the clean target sequence.