### PR TITLE
Declare/define machine data structures in the sub machine header.

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -2265,7 +2265,7 @@ void subMachineHeaderStart(pCMachineData pcmd, pMACHINE_INFO pmi, char *arrayNam
    /* put the data struct typedef into the header file */
    if (pmi->data)
    {
-      fprintf(pcmd->hFile
+	  fprintf(pmi->machine_list ? pcmd->subMachineHFile : pcmd->hFile
 			  , "typedef struct _%s_data_struct_ %s, *p%s;\n"
 			  , pmi->name->name
 			  , fsmDataType(pcmd)
@@ -2275,12 +2275,21 @@ void subMachineHeaderStart(pCMachineData pcmd, pMACHINE_INFO pmi, char *arrayNam
    }
 
    /* put the machine struct typedef into the header */
-   fprintf(pcmd->hFile
+   fprintf(pmi->machine_list ? pcmd->subMachineHFile : pcmd->hFile
 		   , "typedef struct _%s_struct_ %s, *p%s;\n"
 		   , pmi->name->name
 		   , fsmType(pcmd)
 		   , fsmType(pcmd)
 		   );
+
+   if (pmi->machine_list)
+   {
+	   /* The sub-machine header will hold things needed by the private header. */
+	   fprintf(pcmd->hFile
+			   ,"#include \"%s\"\n"
+			   , pcmd->subMachineHName
+			   );
+   }
 
    fprintf(pcmd->hFile
 		   , "#undef FSM_TYPE_PTR\n#define FSM_TYPE_PTR p%s\n"
@@ -2339,27 +2348,22 @@ void subMachineHeaderStart(pCMachineData pcmd, pMACHINE_INFO pmi, char *arrayNam
    /* put the data structure definition into the header */
    if (pmi->data)
    {
-      fprintf(pcmd->hFile
+	  fprintf(pmi->machine_list ? pcmd->subMachineHFile : pcmd->hFile
 			  , "struct _%s_data_struct_ {\n"
 			  , machineName(pcmd)
 			  );
 
       ich.ih.tab_level = 1;
+	  ich.ih.fout      = pmi->machine_list ? pcmd->subMachineHFile : pcmd->hFile;
       iterate_list(pmi->data, print_data_field, &ich);
 
-      fprintf(pcmd->hFile 
+      fprintf(pmi->machine_list ? pcmd->subMachineHFile : pcmd->hFile
               , "};\n\n"
               );
    }
 
    if (pmi->machine_list)
    {
-	   /* The sub-machine header will hold things needed by the private header. */
-	   fprintf(pcmd->hFile
-			   ,"#include \"%s\"\n"
-			   , pcmd->subMachineHName
-			   );
-
 	   printSubMachinesDeclarations(pcmd, pmi);
    }
    

--- a/test/full_test73/Makefile
+++ b/test/full_test73/Makefile
@@ -1,0 +1,19 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -DFSM_DEBUG \
+         -DSUB_DEBUG \
+         -DSUB_SUB_DEBUG \
+         -DTOP_LEVEL_DEBUG \
+         -I../ \
+	 -Wall \
+	 -ggdb
+
+override FSM_FLAGS=--include-svg-img
+
+include ../variants.mk
+
+

--- a/test/full_test73/ss-actions.c
+++ b/test/full_test73/ss-actions.c
@@ -1,0 +1,21 @@
+#include "subSub_priv.h"
+#include <stddef.h>
+
+#ifndef DBG_PRINTF
+#define DBG_PRINTF(...)
+#endif
+
+TEST_EVENT __attribute__((weak)) UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("weak: %s", __func__);
+	(void) pfsm;
+	return THIS(noEvent);
+}
+
+TEST_EVENT __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("weak: %s", __func__);
+	(void) pfsm;
+	return THIS(noEvent);
+}
+

--- a/test/full_test73/sub-actions.c
+++ b/test/full_test73/sub-actions.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include "sub_priv.h"
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+
+	return THIS(noEvent);
+}
+
+void UFMN(onExitFrom_s1)(pSUB_DATA pdata)
+{
+	(void) pdata;
+	printf("%s\n", __func__);
+}
+
+void UFMN(onEntryTo_s2)(pSUB_DATA pdata)
+{
+	(void) pdata;
+	printf("%s\n", __func__);
+}
+

--- a/test/full_test73/test.c
+++ b/test/full_test73/test.c
@@ -1,0 +1,13 @@
+#include "test_fsm.h"
+
+int main(void)
+{
+	run_test(THIS(e1));
+	run_test(THIS(e2));
+	run_test(THIS(e3));
+
+	run_test(SUB(e1));
+
+	return 0;
+}
+

--- a/test/full_test73/test.canonical
+++ b/test/full_test73/test.canonical
@@ -1,0 +1,7 @@
+test_sub_onExitFrom_s1
+test_sub_onEntryTo_s2
+test_a2
+test_a3
+test_transitioning: from=0; to=1
+test_decommission_s1
+test_prep_s2

--- a/test/full_test73/test_fsm.fsm
+++ b/test/full_test73/test_fsm.fsm
@@ -1,0 +1,92 @@
+machine test
+on transition transitioning;
+native impl
+{
+#include <stdio.h>
+#ifdef FSM_VARIANT_C
+#include <string.h>
+#endif
+
+#define INIT_FSM_DATA {.i = 0}
+
+
+void UFMN(transitioning)(FSM_TYPE_PTR pfsm, TEST_STATE to)
+{
+	printf("%s: from=%u; to=%u\n"
+          , __func__
+          , pfsm->state
+          , to
+          );
+}
+
+void UFMN(prep_s2)(pTEST_DATA pdata)
+{
+	(void) pdata;
+	printf("%s\n", __func__);
+}
+
+void UFMN(decommission_s1)(pTEST_DATA pdata)
+{
+	(void) pdata;
+	printf("%s\n", __func__);
+}
+
+}
+
+{
+
+data
+{
+	int i;
+}
+
+	state s1 on exit decommission_s1;
+	state s2 on entry prep_s2;
+	state s3;
+
+	event e1, e2, e3;
+
+	machine sub
+	native impl
+	{
+#define INIT_FSM_DATA {.i = 0}
+	}
+	{
+		data
+		{
+			int i;
+		}
+		state s1 on exit;
+		state s2 on entry;
+		event parent::e1;
+
+		machine subSub
+		native impl
+		{
+	#define INIT_FSM_DATA {.i = 0}
+		}
+		{
+			data
+			{
+				int i;
+			}
+
+			event parent::e1;
+			state s1, s2;
+
+			action a1[e1,s1] transition s2;
+		}
+
+		action always[e1, s1] transition s2;
+		action always[e1, s2];
+	}
+
+	action a1[e1,(s1, s2, s3)];
+	action a2[e2,(s1, s2, s3)];
+
+	action a3[e3, s1] transition s2;
+
+	transition [e3, s2] s3;
+	transition [e3, s3] s1;
+}
+

--- a/test/full_test73/tf-actions.c
+++ b/test/full_test73/tf-actions.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include "test_fsm_priv.h"
+
+#define DBG_PRINTF(...)	printf(__VA_ARGS__); printf("\n");
+
+TEST_EVENT UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return THIS(noEvent);
+}
+
+TEST_EVENT UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return THIS(noEvent);
+}
+
+TEST_EVENT UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	return THIS(noEvent);
+}
+


### PR DESCRIPTION
When sub-machines have data, the parent's data structure, hence, the parent machine structure, must be visible during event sharing.

This PR moves some declarations conditionally to the _submach.h file.

A new full test, which failed before the application of the fix, has been added.