### PR TITLE
143 command line  c switch not compatible with fsm submachines

### DIFF
--- a/linux/system.mk
+++ b/linux/system.mk
@@ -2,7 +2,7 @@
 #make sure that that's what we are using.
 LEX = flex -I 
 YACC = bison -d -y -v #--debug -d
-#CC = gcc -g -ggdb -Werror #-Wall
+#CC = gcc -g -ggdb -Werror -DFSMLANG_DEVELOP #-Wall
 CC = gcc
 DIFF = diff --strip-trailing-cr --ignore-space-change
 override CFLAGS+=-DLINUX

--- a/src/fsm_c.c
+++ b/src/fsm_c.c
@@ -116,9 +116,8 @@ static bool declare_action_enum_member(pLIST_ELEMENT pelem, void *data)
 	{
 
 		fprintf(pich->pcmd->hFile
-				, "%s%s_%s_e\n"
-				, pich->ih.first ? (pich->ih.first = false, "  ") : ", "
-				, fqMachineName(pich->pcmd)
+				, "%sTHIS(%s_e)\n"
+				, pich->ih.first ? (pich->ih.first = false, "\t") : "\t, "
 				, pid_info->name
 			   );
 
@@ -1248,8 +1247,16 @@ static void declareCMachineActionFnEnum(pCMachineData pcmd, pMACHINE_INFO pmi)
 
 	iterate_list(pmi->action_list, declare_action_enum_member, &ich);
 
+	if (empty_cell_fn)
+	{
+		fprintf(pcmd->hFile
+				, "\t, THIS(%s_e)\n"
+				, empty_cell_fn
+				);
+	}
+
 	/* declare the dummy, or no op action */
-	fprintf(pcmd->hFile, ", THIS(noAction_e)\n");
+	fprintf(pcmd->hFile, "\t, THIS(noAction_e)\n");
 
 	fprintf(pcmd->hFile, "} __attribute__((__packed__)) ");
 	fprintf(pcmd->hFile
@@ -1279,10 +1286,17 @@ static void defineCMachineActionFnArray(pCMachineData pcmd, pMACHINE_INFO pmi)
 	/* fill the array */
 	iterate_list(pmi->action_list,  declare_action_array_member, &ich);
 
+	if (empty_cell_fn)
+	{
+		fprintf(pcmd->cFile
+				, "\t, UFMN(%s)\n"
+				, empty_cell_fn
+				);
+	}
+
 	/* declare the dummy, or no op action and close the array */
 	fprintf(pcmd->cFile
-			, "\t, UFMN(%s)\n};\n\n"
-			, empty_cell_fn ? empty_cell_fn : "noAction"
+			, "\t, UFMN(noAction)\n};\n\n"
 			);
 
 }
@@ -1374,20 +1388,20 @@ static void declareCMachineStruct(pCMachineData pcmd, pMACHINE_INFO pmi)
 	if (pmi->data)
 	{
 		fprintf(pcmd->hFile
-				, "\t%-*sdata;\n"
+				, "\t%-*s data;\n"
 				, (int) pcmd->c_machine_struct_format_width
 				, fsmDataType(pcmd)
 				);
 	}
 
 	fprintf(pcmd->hFile
-			, "\t%-*sstate;\n"
+			, "\t%-*s state;\n"
 			, (int) pcmd->c_machine_struct_format_width
 			, stateType(pcmd)
 			);
 
 	fprintf(pcmd->hFile
-			, "\t%-*sevent;\n"
+			, "\t%-*s event;\n"
 			, (int) pcmd->c_machine_struct_format_width
 			, eventType(pcmd)
 			);
@@ -1494,10 +1508,7 @@ static void defineActionArray(pCMachineData pcmd, pMACHINE_INFO pmi)
 							, compacting(pmi) ? "THIS" : "UFMN"
 							, strlen(pmi->actionArray[i][j]->action->name)
 							  ? pmi->actionArray[i][j]->action->name
-							  : (compacting(pmi)
-								 ? "noAction"
-								 : (empty_cell_fn ? empty_cell_fn : "noAction")
-								)
+							  : "noAction"
 							, compacting(pmi) ? "_e" : ""
 						   );
 
@@ -1580,8 +1591,7 @@ static void defineActionArray(pCMachineData pcmd, pMACHINE_INFO pmi)
 					fprintf(pcmd->cFile
 							, "%s(%s%s), "
 							, compacting(pmi) ? "THIS" : "UFMN"
-							, compacting(pmi) ? "noAction"
-							  : (empty_cell_fn ? empty_cell_fn : "noAction")
+							, empty_cell_fn ? empty_cell_fn : "noAction"
 							, compacting(pmi) ? "_e" : ""
 						   );
 

--- a/src/fsm_c.c
+++ b/src/fsm_c.c
@@ -489,10 +489,10 @@ static void writeCMachine(pFSMOutputGenerator pfsmog, pMACHINE_INFO pmi)
 */
 static void writeOriginalFSMAre(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* %s */\n", __func__);
-
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pfsmcog->pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* %s */\n", __func__);
 
  	fprintf(pcmd->cFile
  			, "\t%s new_e;\n"
@@ -523,10 +523,10 @@ static void writeOriginalFSMAre(pFSMCOutputGenerator pfsmcog)
 */
 static void writeOriginalFSMArv(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* %s */\n", __func__);
-
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pfsmcog->pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* %s */\n", __func__);
 
 	if (pmi->executes_fns_on_state_transitions)
 	{
@@ -546,10 +546,10 @@ static void writeOriginalFSMArv(pFSMCOutputGenerator pfsmcog)
 */
 static void writeOriginalSubFSMAre(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
-
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pfsmcog->pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
 
  	fprintf(pcmd->cFile
  			, "\t%s new_e;\n"
@@ -583,10 +583,10 @@ static void writeOriginalSubFSMAre(pFSMCOutputGenerator pfsmcog)
 */
 static void writeOriginalSubFSMArv(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
-
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pfsmcog->pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
 
 	if (pmi->executes_fns_on_state_transitions)
 	{
@@ -609,10 +609,10 @@ static void writeOriginalSubFSMArv(pFSMCOutputGenerator pfsmcog)
 */
 static void writeActionsReturnStateFSM(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
-
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pfsmcog->pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
 
 	fprintf(pcmd->cFile
 			, "\t%s s;\n"
@@ -1667,10 +1667,10 @@ static void defineCMachineFSM(pFSMCOutputGenerator pfsmcog)
 
 static void defineCSubMachineFSM(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
-
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pfsmcog->pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile , "/* %s */\n", __func__ );
 
 	if (pmi->machine_list)
 	{

--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -781,12 +781,15 @@ void commonHeaderEnd(pCMachineData pcmd, pMACHINE_INFO pmi, bool needNoOp)
    /* declare the action functions themselves */
    iterate_list(pmi->action_list, declare_action_function, &ich);
 
+   if (empty_cell_fn)
+   {
+	   print_action_function_declaration(pcmd, empty_cell_fn);
+   }
+
    /* declare the dummy, or no op action */
    if (needNoOp)
    {
-	   print_action_function_declaration(pcmd
-										 , empty_cell_fn ? empty_cell_fn : "noAction"
-										 );
+	   print_action_function_declaration(pcmd, "noAction");
    }
 
    fprintf(pcmd->hFile
@@ -973,9 +976,7 @@ void defineWeakActionFunctionStubs(pCMachineData pcmd, pMACHINE_INFO pmi)
 
 void defineWeakNoActionFunctionStubs(pCMachineData pcmd, pMACHINE_INFO pmi)
 {
-	print_weak_action_function_body_omitting_return_statement(pcmd
-		, empty_cell_fn ? empty_cell_fn : "noAction"
-		);
+	print_weak_action_function_body_omitting_return_statement(pcmd, "noAction");
 
 	if (!(pcmd->pmi->modFlags & mfActionsReturnVoid))
 	{
@@ -2692,6 +2693,13 @@ bool define_event_passing_actions(pLIST_ELEMENT pelem, void *data)
                  , core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
 				 , force_generation_of_event_passing_actions ? "" : "weak: "
                 );
+
+		 if (pich->ih.pmi->data == NULL)
+		 {
+			 fprintf(pich->pcmd->cFile
+					 , "\t(void) pfsm;\n"
+					 );
+		 }
 
          fprintf(pich->pcmd->cFile
                  , "\treturn %s_pass_shared_event(%ssharing_%s_%s);\n}\n\n"

--- a/src/fsm_c_event_table.c
+++ b/src/fsm_c_event_table.c
@@ -425,20 +425,20 @@ static void defineCEventTableMachineStruct(pCMachineData pcmd)
    if (pmi->data)
    {
       fprintf(pcmd->hFile
-			  , "\t%-*sdata;\n"
+			  , "\t%-*s data;\n"
 			  , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 			  , fsmDataType(pcmd)
 			 );
    }
 
    fprintf(pcmd->hFile
-		   , "\t%-*sstate;\n"
+		   , "\t%-*s state;\n"
 		   , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 		   , stateType(pcmd)
 		   );
 
    fprintf(pcmd->hFile
-		   , "\t%-*sevent;\n"
+		   , "\t%-*s event;\n"
 		   , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 		   , eventType(pcmd)
 		  );
@@ -453,7 +453,7 @@ static void defineCEventTableMachineStruct(pCMachineData pcmd)
    if (pmi->machine_list)
    {
       fprintf(pcmd->hFile
-			  , "\tp%-*sconst (*subMachineArray)[%s_numSubMachines];\n"
+			  , "\tp%-*s const (*subMachineArray)[%s_numSubMachines];\n"
 			  , (int)pcmd->sub_machine_struct_format_width
 			  , subFsmIfType(pcmd)
 			   , fqMachineName(pcmd)
@@ -461,7 +461,7 @@ static void defineCEventTableMachineStruct(pCMachineData pcmd)
    }
 
    fprintf(pcmd->hFile
-		   , "\t%-*sfsm;\n};\n\n"
+		   , "\t%-*s fsm;\n};\n\n"
 		   , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 		   , fsmFnType(pcmd)
 		   );
@@ -668,20 +668,10 @@ static void print_event_table_handler_body_for_single_state_or_pai_events_are(FI
 	else 
 	{
 		fprintf(fout, "\tACTION_RETURN_TYPE event = THIS(noEvent);\n\n");
-		if (empty_cell_fn)
-		{
-			fprintf(fout
-					, "\tUFMN(%s)(pfsm);\n"
-					, empty_cell_fn
-					);
-		}
-		else
-		{
-			fprintf(fout
-					, "\tDBG_PRINTF(\"%s_noAction\");\n"
-					, ufMachineName(pcmd)
-					);
-		}
+		fprintf(fout
+				, "\tDBG_PRINTF(\"%s_noAction\");\n"
+				, ufMachineName(pcmd)
+				);
 	}
 
 	if (pai->transition)
@@ -741,20 +731,10 @@ static void print_event_table_handler_body_for_single_state_or_pai_events_arv(FI
 	}
 	else
 	{
-		if (empty_cell_fn)
-		{
-			fprintf(fout
-					, "\tUFMN(%s)(pfsm);\n"
-					, empty_cell_fn
-					);
-		}
-		else
-		{
-			fprintf(fout
-					, "\tDBG_PRINTF(\"%s_noAction\");\n"
-					, ufMachineName(pcmd)
-					);
-		}
+		fprintf(fout
+				, "\tDBG_PRINTF(\"%s_noAction\");\n"
+				, ufMachineName(pcmd)
+				);
 	}
 
 	if (pai->transition)
@@ -833,6 +813,8 @@ static void print_event_table_handler_body_for_single_state_or_pai_events_ars(FI
 
 static void print_event_table_handler_body_for_multiple_state_events_are(FILE *fout, pEVENT_DATA ped, pITERATOR_CALLBACK_HELPER pich)
 {
+	FSMLANG_DEVELOP_PRINTF(fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
+
 	pFSMCOutputGenerator pfsmcog = pich->pfsmcog;
 
 	if (ped->phandling_states->count > 0)
@@ -913,6 +895,8 @@ static void print_event_table_handler_body_for_multiple_state_events_are(FILE *f
 
 static void print_event_table_handler_body_for_multiple_state_events_arv(FILE *fout, pEVENT_DATA ped, pITERATOR_CALLBACK_HELPER pich)
 {
+	FSMLANG_DEVELOP_PRINTF(fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
+
 	pFSMCOutputGenerator pfsmcog = pich->pfsmcog;
 
 	if (ped->phandling_states->count > 0)
@@ -1021,6 +1005,8 @@ static bool print_event_table_handler_state_case_are(pLIST_ELEMENT pelem, void *
 		                                   : NULL
 		                                   ;
 
+	FSMLANG_DEVELOP_PRINTF(fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
+
 	fprintf(fout
 			, "\t\tcase STATE(%s):\n"
 			, pstate->name
@@ -1052,7 +1038,7 @@ static bool print_event_table_handler_state_case_are(pLIST_ELEMENT pelem, void *
 		}
 		else
 		{
-			if (empty_cell_fn)
+			if (empty_cell_fn && (pai->transition == NULL))
 			{
 				fprintf(pich->pcmd->cFile
 						, "\t\t\tUFMN(%s)(pfsm);\n"
@@ -1102,6 +1088,8 @@ static bool print_event_table_handler_state_case_arv(pLIST_ELEMENT pelem, void *
 		                                   ? pmi->actionArray[pevent->order][pnextState->order]
 		                                   : NULL
 		                                   ;
+
+	FSMLANG_DEVELOP_PRINTF(fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
 	fprintf(fout
 			, "\t\tcase STATE(%s):\n"
@@ -1185,6 +1173,8 @@ static bool print_event_table_handler_state_case_ars(pLIST_ELEMENT pelem, void *
 		                                   : NULL
 		                                   ;
 	bool                      handled    = false;
+
+	FSMLANG_DEVELOP_PRINTF(fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
 	fprintf(fout
 			, "\t\tcase STATE(%s):\n"

--- a/src/fsm_c_switch_common.c
+++ b/src/fsm_c_switch_common.c
@@ -115,7 +115,9 @@ void cswitchMachineHeaderEnd(pCMachineData pcmd, pMACHINE_INFO pmi, bool needNoO
    /* declare the dummy, or no op action */
    if (needNoOp)
    {
-      print_action_function_declaration(pcmd, "noAction");
+      print_action_function_declaration(pcmd
+										, empty_cell_fn ? empty_cell_fn : "noAction"
+										);
    }
    fprintf(pcmd->hFile, "\n");
  
@@ -190,10 +192,10 @@ void cswitchMachineHeaderEnd(pCMachineData pcmd, pMACHINE_INFO pmi, bool needNoO
 
 void writeOriginalSwitchFSMLoopAre(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
-
 	pCMachineData pcmd = pfsmcog->pcmd;
     pMACHINE_INFO pmi  = pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
    char *tabstr = "\t";
 
@@ -259,9 +261,10 @@ void writeOriginalSwitchFSMLoopAre(pFSMCOutputGenerator pfsmcog)
 
 void writeOriginalSwitchFSMLoopArv(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
    char *tabstr = "\t";
 
@@ -329,7 +332,9 @@ void cswitchSubMachineHeaderEnd(pCMachineData pcmd, pMACHINE_INFO pmi, bool need
    /* declare the dummy, or no op action */
    if (needNoOp)
    {
-      print_action_function_declaration(pcmd, "noAction");
+      print_action_function_declaration(pcmd
+										 , empty_cell_fn ? empty_cell_fn : "noAction"
+										);
    }
 
    fprintf(pcmd->hFile

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -505,26 +505,26 @@ static void defineCSwitchMachineStruct(pCMachineData pcmd, pMACHINE_INFO pmi)
    if (pmi->data)
    {
       fprintf(pcmd->hFile
-			  , "\t%-*sdata;\n"
+			  , "\t%-*s data;\n"
 			  , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 			  , fsmDataType(pcmd)
 			 );
    }
 
    fprintf(pcmd->hFile
-		   , "\t%-*sstate;\n"
+		   , "\t%-*s state;\n"
 		   , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 		   , stateType(pcmd)
 		   );
 
    fprintf(pcmd->hFile
-		   , "\t%-*sevent;\n"
+		   , "\t%-*s event;\n"
 		   , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 		   , eventType(pcmd)
 		  );
 
    fprintf(pcmd->hFile
-		   , "\t%-*sconst (*statesArray)[%s_numStates];\n"
+		   , "\t%-*s const (*statesArray)[%s_numStates];\n"
 		   , (int)pcmd->sub_machine_struct_format_width
 		   , stateFnType(pcmd)
 		   , machineName(pcmd)
@@ -533,7 +533,7 @@ static void defineCSwitchMachineStruct(pCMachineData pcmd, pMACHINE_INFO pmi)
    if (pmi->machine_list)
    {
       fprintf(pcmd->hFile
-			  , "\tp%-*sconst (*subMachineArray)[%s_numSubMachines];\n"
+			  , "\tp%-*s const (*subMachineArray)[%s_numSubMachines];\n"
 			  , (int)pcmd->sub_machine_struct_format_width
 			  , subFsmIfType(pcmd)
 			   , fqMachineName(pcmd)
@@ -541,7 +541,7 @@ static void defineCSwitchMachineStruct(pCMachineData pcmd, pMACHINE_INFO pmi)
    }
 
    fprintf(pcmd->hFile
-		   , "\t%-*sfsm;\n};\n\n"
+		   , "\t%-*s fsm;\n};\n\n"
 		   , (int)pcmd->sub_machine_struct_format_width + 6 /* for the "const " */
 		   , fsmFnType(pcmd)
 		   );
@@ -1081,21 +1081,11 @@ static bool print_event_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
                 }
                 else
                 {
-					if (empty_cell_fn)
-					{
-						fprintf(pich->pcmd->cFile
-								, "\t\tUFMN(%s)(pfsm);\n"
-								, empty_cell_fn
-								);
-					}
-					else
-					{
-						fprintf(pich->pcmd->cFile
-								, "\t\t%s(\"%s_noAction\");\n"
-								, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
-								, ufMachineName(pich->pcmd)
-							   );
-					}
+					fprintf(pich->pcmd->cFile
+							, "\t\t%s(\"%s_noAction\");\n"
+							, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+							, ufMachineName(pich->pcmd)
+						   );
                 }
 
                 if (pai->transition)
@@ -1485,8 +1475,9 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
 {
    pITERATOR_CALLBACK_HELPER pich  = (pITERATOR_CALLBACK_HELPER) data;
    pID_INFO                  event = (pID_INFO) pelem->mbr;
+   pEVENT_DATA               ped   = &event->type_data.event_data;
 
-   if (event->type_data.event_data.single_pai_for_all_states)
+   if (ped->single_pai_for_all_states)
    {
       pich->counter++;
 
@@ -1498,7 +1489,7 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
 
       if (pich->ih.pmi->modFlags & mfActionsReturnVoid)
       {
-          if (strlen(event->type_data.event_data.psingle_pai->action->name))
+          if (strlen(ped->psingle_pai->action->name))
           {
               if (add_profiling_macros)
               {
@@ -1509,7 +1500,7 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
 
               fprintf(pich->pcmd->cFile
                      , "\t\t\tUFMN(%s)(pfsm);\n"
-                     , event->type_data.event_data.psingle_pai->action->name
+                     , ped->psingle_pai->action->name
                      );
 
               if (add_profiling_macros)
@@ -1522,31 +1513,21 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
           }
           else
           {
-			  if (empty_cell_fn)
-			  {
-				  fprintf(pich->pcmd->cFile
-						  , "\t\tUFMN(%s)(pfsm);\n"
-						  , empty_cell_fn
-						  );
-			  }
-			  else
-			  {
-				  fprintf(pich->pcmd->cFile
-						  , "\t\tDBG_PRINTF(\"%s_noAction\");\n"
-						  , ufMachineName(pich->pcmd)
-						 );
-			  }
+			  fprintf(pich->pcmd->cFile
+					  , "\t\tDBG_PRINTF(\"%s_noAction\");\n"
+					  , ufMachineName(pich->pcmd)
+					 );
           }
 
-         if (event->type_data.event_data.psingle_pai->transition)
+         if (ped->psingle_pai->transition)
          {
             fprintf(pich->pcmd->cFile
                     , "\t\t\t%s = UFMN(%s)%s;\n"
                      , (pich->ih.pmi->executes_fns_on_state_transitions)
                       ? "new_s" 
                       : "pfsm->state"
-                    , event->type_data.event_data.psingle_pai->transition->name
-                    , event->type_data.event_data.psingle_pai->transition->type == STATE
+                    , ped->psingle_pai->transition->name
+                    , ped->psingle_pai->transition->type == STATE
                        ? ""
                        : "(pfsm,e)"
                     );
@@ -1571,7 +1552,7 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
 
              fprintf(pich->pcmd->cFile
                      , "\t\t\tretVal = UFMN(%s)(pfsm);\n"
-                     , event->type_data.event_data.psingle_pai->action->name
+                     , ped->psingle_pai->action->name
                      );
 
              if (add_profiling_macros)
@@ -1585,7 +1566,7 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
           else
           {
              fprintf(pich->pcmd->cFile,"\t\t\tretVal = THIS(noEvent);\n");
-			 if (empty_cell_fn)
+			 if (empty_cell_fn && (ped->psingle_pai->transition == NULL))
 			 {
 				 fprintf(pich->pcmd->cFile
 						 , "\t\tUFMN(%s)(pfsm);\n"
@@ -1600,14 +1581,14 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
 						 );
 			 }
           }
-          if (event->type_data.event_data.psingle_pai->transition)
+          if (ped->psingle_pai->transition)
           {
              fprintf(pich->pcmd->cFile
                      , "\t\t\t%s = UFMN(%s)%s;\n"
                      , pich->pcmd->pmi->executes_fns_on_state_transitions
                        ? "new_s" : "pfsm->state"
-                     , event->type_data.event_data.psingle_pai->transition->name
-                     , event->type_data.event_data.psingle_pai->transition->type == STATE
+                     , ped->psingle_pai->transition->name
+                     , ped->psingle_pai->transition->type == STATE
                         ? ""
                         : "(pfsm,e)"
                      );

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -292,7 +292,7 @@ static int writeCSwitchMachineInternal(pFSMCOutputGenerator pfsmcog)
 
    fprintf(pcmd->hFile, "\n");
 
-   cswitchMachineHeaderEnd(pcmd, pmi, false);
+   cswitchMachineHeaderEnd(pcmd, pmi, empty_cell_fn != NULL);
 
    /*
      Source File
@@ -413,7 +413,7 @@ static int writeCSwitchSubMachineInternal(pFSMCOutputGenerator pfsmcog)
 
    fprintf(pcmd->hFile, "\n");
 
-   cswitchSubMachineHeaderEnd(pcmd, pmi, false);
+   cswitchSubMachineHeaderEnd(pcmd, pmi, empty_cell_fn != NULL);
 
    /*
      Source File
@@ -752,11 +752,23 @@ static bool define_void_returning_state_fn(pLIST_ELEMENT pelem, void *data)
 
     if (pich->counter < pich->ih.pmi->event_list->count + 1)
     {
-        fprintf(pich->pcmd->cFile
-                , "\tdefault:\n\t\t%s(\"%s_noAction\");\n\t\tbreak;\n"
-                , core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
-                , ufMachineName(pich->pcmd)
-               );
+		fprintf(pich->pcmd->cFile, "\tdefault:\n");
+		if (empty_cell_fn)
+		{
+			fprintf(pich->pcmd->cFile
+					, "\t\tUFMN(%s)(pfsm);\n"
+					, empty_cell_fn
+					);
+		}
+		else
+		{
+			fprintf(pich->pcmd->cFile
+					, "\t\t%s(\"%s_noAction\");\n"
+					, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+					, ufMachineName(pich->pcmd)
+				   );
+		}
+		fprintf(pich->pcmd->cFile, "\t\tbreak;\n");
     }
 
     fprintf(pich->pcmd->cFile, "\t}\n");
@@ -874,11 +886,23 @@ static bool define_event_returning_state_fn(pLIST_ELEMENT pelem, void *data)
 
     if (pich->counter < pich->ih.pmi->event_list->count + 1)
     {
-        fprintf(pich->pcmd->cFile
-                , "\tdefault:\n\t\t%s(\"%s_noAction\");\n\t\tbreak;\n"
-                , core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
-                , ufMachineName(pich->pcmd)
-               );
+		fprintf(pich->pcmd->cFile, "\tdefault:\n");
+		if (empty_cell_fn)
+		{
+			fprintf(pich->pcmd->cFile
+					, "\t\tUFMN(%s)(pfsm);\n"
+					, empty_cell_fn
+					);
+		}
+		else
+		{
+			fprintf(pich->pcmd->cFile
+					, "\t\t%s(\"%s_noAction\");\n"
+					, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+					, ufMachineName(pich->pcmd)
+				   );
+		}
+		fprintf(pich->pcmd->cFile, "\t\tbreak;\n");
     }
 
     fprintf(pich->pcmd->cFile, "\t}\n");
@@ -936,11 +960,23 @@ static bool define_state_returning_state_fn(pLIST_ELEMENT pelem, void *data)
 
     if (pich->counter < pich->ih.pmi->event_list->count + 1)
     {
-        fprintf(pich->pcmd->cFile
-                , "\tdefault:\n\t\t%s(\"%s_noAction\");\n\t\tbreak;\n"
-                , core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
-                , ufMachineName(pich->pcmd)
-               );
+		fprintf(pich->pcmd->cFile, "\tdefault:\n");
+		if (empty_cell_fn)
+		{
+			fprintf(pich->pcmd->cFile
+					, "\t\tUFMN(%s)(pfsm);\n"
+					, empty_cell_fn
+					);
+		}
+		else
+		{
+			fprintf(pich->pcmd->cFile
+					, "\t\t%s(\"%s_noAction\");\n"
+					, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+					, ufMachineName(pich->pcmd)
+				   );
+		}
+		fprintf(pich->pcmd->cFile, "\t\tbreak;\n");
     }
 
     fprintf(pich->pcmd->cFile, "\t}\n");
@@ -1045,12 +1081,21 @@ static bool print_event_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
                 }
                 else
                 {
-                    fprintf(pich->pcmd->cFile
-                            , "#ifdef %s\n\t\t%s(\"%s_noAction\");\n#endif\n"
-                            , ucfqMachineName(pich->pcmd)
-                            , core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
-                            , ufMachineName(pich->pcmd)
-                            );
+					if (empty_cell_fn)
+					{
+						fprintf(pich->pcmd->cFile
+								, "\t\tUFMN(%s)(pfsm);\n"
+								, empty_cell_fn
+								);
+					}
+					else
+					{
+						fprintf(pich->pcmd->cFile
+								, "\t\t%s(\"%s_noAction\");\n"
+								, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+								, ufMachineName(pich->pcmd)
+							   );
+					}
                 }
 
                 if (pai->transition)
@@ -1146,12 +1191,23 @@ static bool print_void_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
                 }
                 else
                 {
-                    fprintf(pich->pcmd->cFile
-                            , "#ifdef %s_DEBUG\n\t\t%s(\"%s_noAction\");\n#endif\n"
-                            , ucfqMachineName(pich->pcmd)
-                            , core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
-                           , ufMachineName(pich->pcmd)
-                            );
+					fprintf(pich->pcmd->cFile, "\tdefault:\n");
+					if (empty_cell_fn)
+					{
+						fprintf(pich->pcmd->cFile
+								, "\t\tUFMN(%s)(pfsm);\n"
+								, empty_cell_fn
+								);
+					}
+					else
+					{
+						fprintf(pich->pcmd->cFile
+								, "\t\t%s(\"%s_noAction\");\n"
+								, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+								, ufMachineName(pich->pcmd)
+							   );
+					}
+					fprintf(pich->pcmd->cFile, "\t\tbreak;\n");
                 }
 
                 if (pai->transition)
@@ -1466,10 +1522,20 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
           }
           else
           {
-              fprintf(pich->pcmd->cFile
-                      , "\t\t\tDBG_PRINTF(\"%s_noAction\");\n"
-                      , ufMachineName(pich->pcmd)
-                      );
+			  if (empty_cell_fn)
+			  {
+				  fprintf(pich->pcmd->cFile
+						  , "\t\tUFMN(%s)(pfsm);\n"
+						  , empty_cell_fn
+						  );
+			  }
+			  else
+			  {
+				  fprintf(pich->pcmd->cFile
+						  , "\t\tDBG_PRINTF(\"%s_noAction\");\n"
+						  , ufMachineName(pich->pcmd)
+						 );
+			  }
           }
 
          if (event->type_data.event_data.psingle_pai->transition)
@@ -1519,10 +1585,20 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
           else
           {
              fprintf(pich->pcmd->cFile,"\t\t\tretVal = THIS(noEvent);\n");
-             fprintf(pich->pcmd->cFile
-                     , "\t\t\tDBG_PRINTF(\"%s_noAction\");\n"
-                     , ufMachineName(pich->pcmd)
-                     );
+			 if (empty_cell_fn)
+			 {
+				 fprintf(pich->pcmd->cFile
+						 , "\t\tUFMN(%s)(pfsm);\n"
+						 , empty_cell_fn
+						 );
+			 }
+			 else
+			 {
+				 fprintf(pich->pcmd->cFile
+						 , "\t\t\tDBG_PRINTF(\"%s_noAction\");\n"
+						 , ufMachineName(pich->pcmd)
+						 );
+			 }
           }
           if (event->type_data.event_data.psingle_pai->transition)
           {

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -654,9 +654,10 @@ static void defineCSwitchMachineFSM(pFSMCOutputGenerator pfsmcog)
 
 static void defineCSwitchSubMachineFSM(pFSMCOutputGenerator pfsmcog)
 {
-	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pcmd->pmi;
+
+	FSMLANG_DEVELOP_PRINTF(pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
    if (pmi->machine_list)
    {

--- a/src/fsm_priv.h
+++ b/src/fsm_priv.h
@@ -390,6 +390,7 @@ unsigned maxDepth(pMACHINE_INFO);
 void print_tab_levels(FILE*,unsigned);
 void streamStrCaseAware(FILE*,char*,ANCESTRY_LETTER_CASE);
 void increase_sub_machine_depth(pMACHINE_INFO);
+bool compacting(pMACHINE_INFO);
 
 #ifdef PARSER_DEBUG
 void parser_debug_print_state_list(pLIST,FILE*);
@@ -431,6 +432,7 @@ extern bool                 print_action_array;
 extern bool                 convenience_macros_in_public_header;
 extern bool                 add_profiling_macros;
 extern bool                 profile_sub_fsms;
+extern char                 *empty_cell_fn;
 
 #define LOOKUP	0	/* default - not defined in the parser */
 

--- a/src/fsm_utils.c
+++ b/src/fsm_utils.c
@@ -111,6 +111,7 @@ bool  output_generated_file_names_only          = false;
 bool  output_header_files                       = false;
 bool  output_make_recipe                        = false;
 bool  short_user_fn_names                       = false;
+char  *empty_cell_fn                            = NULL;
 
 void print_tab_levels(FILE *output, unsigned levels)
 {
@@ -1528,6 +1529,33 @@ char *create_string_from_file(FILE *file, unsigned long *str_len)
 	}
 
 	return cp;
+}
+
+/**
+ * Allow compacting only when actions return events.  Set the
+ * compacting request flag to false so that code generation will
+ * proceed without compacting.
+ * 
+ * @author Steven Stanton (2/2/2025)
+ * 
+ * @param pmi    
+ * 
+ * @return bool	true iff compact structures are requested and
+ *  	   allowed.
+ */
+bool compacting(pMACHINE_INFO pmi)
+{
+	if (compact_action_array && (pmi->modFlags & ACTIONS_RETURN_FLAGS))
+	{
+		fprintf(stderr
+				, "Warning: Ignoring compact array request because actions do not return events.\n"
+				);
+		compact_action_array = false;
+	}
+
+	return compact_action_array
+		   && !(pmi->modFlags & ACTIONS_RETURN_FLAGS)
+	       ;
 }
 
 #ifdef PARSER_DEBUG

--- a/src/parser.y
+++ b/src/parser.y
@@ -2194,6 +2194,7 @@ typedef enum {
  , lo_convenience_macro_in_public_header
  , lo_add_profiling_macros
  , lo_profile_sub_fsms
+ , lo_empty_cell_fn
 } LONG_OPTIONS;
 
 int longindex = 0;
@@ -2349,6 +2350,12 @@ const struct option longopts[] =
         , .has_arg = optional_argument
         , .flag    = &longval
 				, .val     = lo_profile_sub_fsms
+    }
+		, {
+        .name      = "empty-cell-fn"
+        , .has_arg = required_argument
+        , .flag    = &longval
+				, .val     = lo_empty_cell_fn
     }
     , {0}
 };
@@ -2526,6 +2533,9 @@ int main(int argc, char **argv)
 								profile_sub_fsms = true;
 							}
 							break;
+            case lo_empty_cell_fn:
+                empty_cell_fn = optarg;
+                break;
             default:
                 usage();
                 return(0);
@@ -3126,7 +3136,7 @@ void usage(void)
 		 , list_item_end
 		 );
  fprintf(stdout
-		 ,"%s-Md print a lines suitable for inclusion in a Makefile giving the recipe for%s"
+		 ,"%s-Md print a line suitable for inclusion in a Makefile giving the recipe for%s"
 		 , item_start
 		 , list_start
 		 );
@@ -3166,6 +3176,18 @@ void usage(void)
 		 );
  fprintf(stdout
 		 ,"%smust also be enabled.%s"
+		 , inner_item_start
+		 , list_item_end
+		 );
+ fprintf(stdout
+		 ,"%s--empty-cell-fn=%sname%s designates a function to be called when%s"
+		 , item_start
+      , lt
+      , gt
+		 , list_start
+		 );
+ fprintf(stdout
+		 ,"%san event/state cell is empty.%s"
 		 , inner_item_start
 		 , list_item_end
 		 );

--- a/src/parser.y
+++ b/src/parser.y
@@ -2735,7 +2735,7 @@ void usage(void)
 	char *item_end         = html_help ? "</li>\n"                   : "\n";
 	char *list_item_end    = html_help ? "</li>\n\t</ul>\n</li>\n"   : "\n";
 	char *lt               = html_help ? "&lt;"                      : "<";
-	char *gt               = html_help ? "&gt;"                      : "<";
+	char *gt               = html_help ? "&gt;"                      : ">";
 
 	fprintf(stdout
 			, "%s%sUsage : %s [-tc|s|e|h|p|r] [-o outfile] [-s] filename, where filename ends with '.fsm'%s"

--- a/src/revision.c
+++ b/src/revision.c
@@ -405,5 +405,13 @@
 	Declaration and definition of machine structure is moved to _submach.h when necessary to
 	support event sharing when machines involved have data.
 */
-const char rev_string[] = "1.44.1";
+
+/*
+	Revision 1.45.0-alpha.1
+
+	implement --empty-cell-fn=<fn name> to allow user to designate a
+	function two be called when the state machine encounters an empty
+	event/state cell.
+*/
+const char rev_string[] = "1.45.0-alpha.1";
 

--- a/test/full_test10/test.canonical
+++ b/test/full_test10/test.canonical
@@ -21,4 +21,4 @@ newMachine_machineTransitionFn
 	new state: newMachine_s3
 
 end state: newMachine_s3
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test100/Makefile
+++ b/test/full_test100/Makefile
@@ -1,0 +1,17 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -DTEST_EMPTY_CELLS_DEBUG \
+         -DTEST_EMPTY_CELLS_SUB_DEBUG       \
+			-I../                              \
+	 		-Wall                              \
+	 		-ggdb
+
+override FSM_FLAGS+=--empty-cell-fn=i_am_empty
+
+include ../variants.mk
+
+

--- a/test/full_test100/s-actions.c
+++ b/test/full_test100/s-actions.c
@@ -1,0 +1,23 @@
+#include "sub_priv.h"
+
+TEST_EMPTY_CELLS_EVENT UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+TEST_EMPTY_CELLS_EVENT UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return THIS(noEvent);
+}
+

--- a/test/full_test100/tec-actions.c
+++ b/test/full_test100/tec-actions.c
@@ -1,0 +1,62 @@
+#include "test_empty_cells_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+#if defined(FSM_VARIANT_CC)
+TEST_EMPTY_CELLS_EVENT UFMN(share)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return test_empty_cells_pass_shared_event(sharing_test_empty_cells_e3);
+}
+#endif
+
+ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+int main(void)
+{
+	run_test_empty_cells(THIS(e1));	//prints a1
+
+	ptest_empty_cells->state = test_empty_cells_s1;
+	run_test_empty_cells(THIS(e2));	//prints noAction
+
+	ptest_empty_cells->state = test_empty_cells_s1;
+	run_test_empty_cells(THIS(e3));	//prints SUB(a1)
+
+	ptest_empty_cells->state = test_empty_cells_s1;
+	set_sub_state_s2();
+	run_test_empty_cells(THIS(e3));	//prints SUB(noAction)
+
+	ptest_empty_cells->state = test_empty_cells_s1;
+	set_sub_state_s3();
+	run_test_empty_cells(THIS(e3));	//prints i_am_empty
+
+	ptest_empty_cells->state = test_empty_cells_s2;
+	run_test_empty_cells(THIS(e1));	//prints i_am_empty
+
+	ptest_empty_cells->state = test_empty_cells_s2;
+	run_test_empty_cells(THIS(e2));	//prints i_am_empty
+
+	ptest_empty_cells->state = test_empty_cells_s2;
+	run_test_empty_cells(THIS(e3));	//prints i_am_empty
+
+	return 0;
+}
+

--- a/test/full_test100/test.canonical
+++ b/test/full_test100/test.canonical
@@ -1,0 +1,22 @@
+event: test_empty_cells_e1; state: test_empty_cells_s1
+test_empty_cells_a1
+event: test_empty_cells_e2; state: test_empty_cells_s1
+test_empty_cells_noAction
+event: test_empty_cells_e3; state: test_empty_cells_s1
+test_empty_cells_share
+event: test_empty_cells_sub_e3; state: test_empty_cells_sub_s1
+test_empty_cells_sub_a1
+event: test_empty_cells_e3; state: test_empty_cells_s1
+test_empty_cells_share
+event: test_empty_cells_sub_e3; state: test_empty_cells_sub_s2
+test_empty_cells_sub_noAction
+event: test_empty_cells_e3; state: test_empty_cells_s1
+test_empty_cells_share
+event: test_empty_cells_sub_e3; state: test_empty_cells_sub_s3
+test_empty_cells_sub_i_am_empty
+event: test_empty_cells_e1; state: test_empty_cells_s2
+test_empty_cells_i_am_empty
+event: test_empty_cells_e2; state: test_empty_cells_s2
+test_empty_cells_i_am_empty
+event: test_empty_cells_e3; state: test_empty_cells_s2
+test_empty_cells_i_am_empty

--- a/test/full_test100/test_empty_cells.fsm
+++ b/test/full_test100/test_empty_cells.fsm
@@ -1,0 +1,63 @@
+native
+{
+#include "test.h"
+extern void set_sub_state_s1(void);
+extern void set_sub_state_s2(void);
+extern void set_sub_state_s3(void);
+}
+
+/*
+	The new --empty-cell-fn=<fn_name> should result in fn_name being
+		called iff there is no action or transition for a given
+		event/state cell.
+
+	Action a1 is defined in e1,s1.
+	A transition is defined in e2, s1.
+
+	Event e3 is shared to the sub machine via action share in s1.
+
+	Within the sub machine:
+
+		Action a1 is defined in e3, s1.
+
+		A transition is defined in e3, s2.
+*/
+machine test_empty_cells
+{
+
+	event e1, e2, e3;
+	state s1, s2;
+
+	machine sub
+	native impl epilogue
+	{
+		void set_sub_state_s1()
+      {
+			psub->state = STATE(s1);
+		}
+
+		void set_sub_state_s2()
+      {
+			psub->state = STATE(s2);
+		}
+
+		void set_sub_state_s3()
+      {
+			psub->state = STATE(s3);
+		}
+
+	}
+	{
+		event parent::e3;
+		state s1, s2, s3;
+
+		action a1[e3, s1];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1];
+	[e2, s1] transition s2;
+	action share[e3, s1];
+
+}
+

--- a/test/full_test11/test.canonical
+++ b/test/full_test11/test.canonical
@@ -21,4 +21,4 @@ newMachine_machineTransitionFn
 	new state: newMachine_s3
 
 end state: newMachine_s3
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test18/test.canonical
+++ b/test/full_test18/test.canonical
@@ -2,4 +2,4 @@ event: newMachine_e1; state: newMachine_s1
 newMachine_a1
 event: newMachine_subMachine1_ee1; state: newMachine_s1
 subMachine1_aa1
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test27/test.canonical
+++ b/test/full_test27/test.canonical
@@ -78,11 +78,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 top_level_sub_machine1_handle_e7
@@ -111,11 +111,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 top_level_sub_machine1_handle_e7
@@ -144,11 +144,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 top_level_sub_machine1_handle_e7
@@ -177,11 +177,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 top_level_sub_machine1_handle_e7
@@ -210,11 +210,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 top_level_sub_machine1_handle_e7

--- a/test/full_test27/tl-actions.c
+++ b/test/full_test27/tl-actions.c
@@ -36,14 +36,14 @@ TOP_LEVEL_EVENT UFMN(noAction)(pTOP_LEVEL pfsm)
 
 TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(FSM_TYPE_PTR pfsm)
 {
-	DBG_PRINTF("weak: %s", __func__);
+	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
 }
 
 TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(FSM_TYPE_PTR pfsm)
 {
-	DBG_PRINTF("weak: %s", __func__);
+	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
 }

--- a/test/full_test28/test.canonical
+++ b/test/full_test28/test.canonical
@@ -79,11 +79,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 0
@@ -116,11 +116,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 1
@@ -153,11 +153,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 2
@@ -190,11 +190,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 3
@@ -227,11 +227,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 4

--- a/test/full_test28/tl-actions.c
+++ b/test/full_test28/tl-actions.c
@@ -36,14 +36,14 @@ TOP_LEVEL_EVENT UFMN(noAction)(pTOP_LEVEL pfsm)
 
 TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(FSM_TYPE_PTR pfsm)
 {
-	DBG_PRINTF("weak: %s", __func__);
+	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
 }
 
 TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(FSM_TYPE_PTR pfsm)
 {
-	DBG_PRINTF("weak: %s", __func__);
+	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
 }

--- a/test/full_test29/test.canonical
+++ b/test/full_test29/test.canonical
@@ -74,11 +74,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 0
@@ -111,11 +111,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 1
@@ -148,11 +148,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 2
@@ -185,11 +185,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 3
@@ -222,11 +222,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 4

--- a/test/full_test29/tl-actions.c
+++ b/test/full_test29/tl-actions.c
@@ -37,3 +37,15 @@ TOP_LEVEL_EVENT __attribute__((weak)) UFMN(a1)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
+}
+
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
+}
+

--- a/test/full_test30/test.canonical
+++ b/test/full_test30/test.canonical
@@ -74,11 +74,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 0
@@ -111,11 +111,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 1
@@ -148,11 +148,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 2
@@ -185,11 +185,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 3
@@ -222,11 +222,11 @@ top_level_sub_machine3_a2
 top_level_sub_machine3_a3
 
 event: top_level_e6; state: top_level_s3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 4

--- a/test/full_test30/tl-actions.c
+++ b/test/full_test30/tl-actions.c
@@ -37,3 +37,15 @@ TOP_LEVEL_EVENT __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
+}
+
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
+}
+

--- a/test/full_test31/test.canonical
+++ b/test/full_test31/test.canonical
@@ -73,11 +73,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 0
@@ -109,11 +109,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 1
@@ -145,11 +145,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 2
@@ -181,11 +181,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 3
@@ -217,11 +217,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 4

--- a/test/full_test31/tl-actions.c
+++ b/test/full_test31/tl-actions.c
@@ -37,3 +37,15 @@ TOP_LEVEL_EVENT __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
+}
+
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
+}
+

--- a/test/full_test32/test.canonical
+++ b/test/full_test32/test.canonical
@@ -73,11 +73,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 0
@@ -109,11 +109,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 1
@@ -145,11 +145,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 2
@@ -181,11 +181,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 3
@@ -217,11 +217,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 4

--- a/test/full_test32/tl-actions.c
+++ b/test/full_test32/tl-actions.c
@@ -37,3 +37,15 @@ TOP_LEVEL_EVENT __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
+}
+
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
+}
+

--- a/test/full_test34/test.canonical
+++ b/test/full_test34/test.canonical
@@ -74,11 +74,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 0
@@ -112,11 +112,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 1
@@ -150,11 +150,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 2
@@ -188,11 +188,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 3
@@ -226,11 +226,11 @@ top_level_sub_machine3_a2
 
 top_level_sub_machine3_a3
 
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 
 The int: 4

--- a/test/full_test34/tl-actions.c
+++ b/test/full_test34/tl-actions.c
@@ -35,3 +35,15 @@ TOP_LEVEL_EVENT __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
+}
+
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
+}
+

--- a/test/full_test37/test.canonical
+++ b/test/full_test37/test.canonical
@@ -45,11 +45,11 @@ event: top_level_sub_machine3_e1; state: top_level_s3
 top_level_sub_machine3_a1
 top_level_sub_machine3_a2
 top_level_sub_machine3_a3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 The int: 0
 
@@ -72,11 +72,11 @@ event: top_level_sub_machine3_e1; state: top_level_s3
 top_level_sub_machine3_a1
 top_level_sub_machine3_a2
 top_level_sub_machine3_a3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 The int: 1
 
@@ -99,11 +99,11 @@ event: top_level_sub_machine3_e1; state: top_level_s3
 top_level_sub_machine3_a1
 top_level_sub_machine3_a2
 top_level_sub_machine3_a3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 The int: 2
 
@@ -126,11 +126,11 @@ event: top_level_sub_machine3_e1; state: top_level_s3
 top_level_sub_machine3_a1
 top_level_sub_machine3_a2
 top_level_sub_machine3_a3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 The int: 3
 
@@ -153,11 +153,11 @@ event: top_level_sub_machine3_e1; state: top_level_s3
 top_level_sub_machine3_a1
 top_level_sub_machine3_a2
 top_level_sub_machine3_a3
-weak: top_level_handle_dispatch
+top_level_handle_dispatch
 top_level_sub_machine1_noAction
 top_level_sub_machine2_noAction
 event: top_level_e7; state: top_level_s3
-weak: top_level_handle_other_passed_event
+top_level_handle_other_passed_event
 top_level_sub_machine1_translate_e7_data
 The int: 4
 

--- a/test/full_test37/tl-actions.c
+++ b/test/full_test37/tl-actions.c
@@ -37,3 +37,15 @@ TOP_LEVEL_EVENT __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_dispatch)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e6);
+}
+
+TOP_LEVEL_EVENT __attribute__((weak)) UFMN(handle_other_passed_event)(pTOP_LEVEL pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return top_level_pass_shared_event(pfsm, sharing_top_level_e7);
+}
+

--- a/test/full_test46/test.canonical
+++ b/test/full_test46/test.canonical
@@ -145,7 +145,7 @@ event: newMachine_subMachine1_ee3; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -170,7 +170,7 @@ event: newMachine_subMachine2_eee1; state: newMachine_s4
 weak: newMachine_subMachine2_aaa1
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -193,7 +193,7 @@ event: newMachine_subMachine2_eee1; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -218,7 +218,7 @@ event: newMachine_subMachine2_eee2; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -241,7 +241,7 @@ event: newMachine_subMachine2_eee2; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -266,7 +266,7 @@ event: newMachine_subMachine2_eee3; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -305,7 +305,7 @@ event: newMachine_subMachine1_ee2; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -328,7 +328,7 @@ event: newMachine_subMachine1_ee2; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.
@@ -367,7 +367,7 @@ event: newMachine_subMachine1_ee3; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 
 sub_machine1.data.cp: Good-bye, world.

--- a/test/full_test46/tl-actions.c
+++ b/test/full_test46/tl-actions.c
@@ -148,3 +148,9 @@ NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
+}
+

--- a/test/full_test47/test.canonical
+++ b/test/full_test47/test.canonical
@@ -129,7 +129,7 @@ newMachine_subMachine1_noAction
 
 marker 12
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -152,7 +152,7 @@ weak: newMachine_subMachine2_aaa1
 
 marker 14
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -173,7 +173,7 @@ newMachine_subMachine2_noAction
 
 marker 15
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -196,7 +196,7 @@ newMachine_subMachine2_noAction
 
 marker 17
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -218,7 +218,7 @@ newMachine_subMachine2_noAction
 
 marker 19
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -241,7 +241,7 @@ newMachine_subMachine2_noAction
 
 marker 21
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -278,7 +278,7 @@ newMachine_subMachine1_noAction
 
 marker 24
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -300,7 +300,7 @@ newMachine_subMachine1_noAction
 
 marker 26
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 
@@ -337,7 +337,7 @@ newMachine_subMachine1_noAction
 
 marker 29
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 subMachine1.data.cp: Good-bye, world.
 

--- a/test/full_test47/tl-actions.c
+++ b/test/full_test47/tl-actions.c
@@ -119,3 +119,9 @@ NEW_MACHINE_STATE __attribute__((weak)) UFMN(noTransitionFn)(pNEW_MACHINE pfsm, 
 	return pfsm->state;
 }
 
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
+}
+

--- a/test/full_test48/test.canonical
+++ b/test/full_test48/test.canonical
@@ -117,7 +117,7 @@ event: newMachine_subMachine1_ee3; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -138,7 +138,7 @@ event: newMachine_subMachine2_eee1; state: newMachine_s4
 weak: newMachine_subMachine2_aaa1
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -158,7 +158,7 @@ event: newMachine_subMachine2_eee1; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -179,7 +179,7 @@ event: newMachine_subMachine2_eee2; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -199,7 +199,7 @@ event: newMachine_subMachine2_eee2; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -220,7 +220,7 @@ event: newMachine_subMachine2_eee3; state: newMachine_s4
 newMachine_subMachine2_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -254,7 +254,7 @@ event: newMachine_subMachine1_ee2; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -274,7 +274,7 @@ event: newMachine_subMachine1_ee2; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -308,7 +308,7 @@ event: newMachine_subMachine1_ee3; state: newMachine_s4
 newMachine_subMachine1_noAction
 
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 

--- a/test/full_test48/tl-actions.c
+++ b/test/full_test48/tl-actions.c
@@ -119,3 +119,9 @@ NEW_MACHINE_STATE __attribute__((weak)) UFMN(noTransitionFn)(pNEW_MACHINE pfsm, 
 	return pfsm->state;
 }
 
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
+}
+

--- a/test/full_test49/test.canonical
+++ b/test/full_test49/test.canonical
@@ -129,7 +129,7 @@ newMachine_subMachine1_noAction
 
 marker 12
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -152,7 +152,7 @@ weak: newMachine_subMachine2_aaa1
 
 marker 14
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -173,7 +173,7 @@ newMachine_subMachine2_noAction
 
 marker 15
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -196,7 +196,7 @@ newMachine_subMachine2_noAction
 
 marker 17
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -218,7 +218,7 @@ newMachine_subMachine2_noAction
 
 marker 19
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -241,7 +241,7 @@ newMachine_subMachine2_noAction
 
 marker 21
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -278,7 +278,7 @@ newMachine_subMachine1_noAction
 
 marker 24
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -300,7 +300,7 @@ newMachine_subMachine1_noAction
 
 marker 26
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -337,7 +337,7 @@ newMachine_subMachine1_noAction
 
 marker 29
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 

--- a/test/full_test49/tl-actions.c
+++ b/test/full_test49/tl-actions.c
@@ -119,3 +119,9 @@ NEW_MACHINE_STATE __attribute__((weak)) UFMN(noTransitionFn)(pNEW_MACHINE pfsm, 
 	return pfsm->state;
 }
 
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
+}
+

--- a/test/full_test5/test.canonical
+++ b/test/full_test5/test.canonical
@@ -1,2 +1,2 @@
 hello, world
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test55/test.canonical
+++ b/test/full_test55/test.canonical
@@ -129,7 +129,7 @@ newMachine_subMachine1_noAction
 
 marker 12
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -152,7 +152,7 @@ weak: newMachine_subMachine2_aaa1
 
 marker 14
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -173,7 +173,7 @@ newMachine_subMachine2_noAction
 
 marker 15
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -196,7 +196,7 @@ newMachine_subMachine2_noAction
 
 marker 17
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -218,7 +218,7 @@ newMachine_subMachine2_noAction
 
 marker 19
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -241,7 +241,7 @@ newMachine_subMachine2_noAction
 
 marker 21
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -278,7 +278,7 @@ newMachine_subMachine1_noAction
 
 marker 24
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -300,7 +300,7 @@ newMachine_subMachine1_noAction
 
 marker 26
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -337,7 +337,7 @@ newMachine_subMachine1_noAction
 
 marker 29
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 

--- a/test/full_test55/tl-actions.c
+++ b/test/full_test55/tl-actions.c
@@ -3,7 +3,6 @@
 
 #include "top_level_priv.h"
 
-// provided by test.c
 extern void print_newMachine_data(pNEW_MACHINE_DATA);
 
 void newMachine_translate_e1_data(pNEW_MACHINE_DATA pfsm_data, pNEW_MACHINE_E1_DATA pevent_data)
@@ -101,8 +100,8 @@ NEW_MACHINE_EVENT_ENUM newMachine_doNothing(pNEW_MACHINE pfsm)
 
 NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(noAction)(FSM_TYPE_PTR pfsm)
 {
-	(void) pfsm;
 	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
 	return THIS(noEvent);
 }
 
@@ -118,5 +117,11 @@ NEW_MACHINE_STATE __attribute__((weak)) UFMN(noTransitionFn)(pNEW_MACHINE pfsm, 
 {
 	(void) e;
 	return pfsm->state;
+}
+
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
 }
 

--- a/test/full_test6/test.canonical
+++ b/test/full_test6/test.canonical
@@ -12,4 +12,4 @@ newMachine_noAction
 newMachine_transitionFn1
 event: newMachine_e4; state: newMachine_s2
 newMachine_noAction
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test7/test.canonical
+++ b/test/full_test7/test.canonical
@@ -13,4 +13,4 @@ newMachine_noAction
 newMachine_transitionFn1
 event: newMachine_e4; state: newMachine_s2
 newMachine_noAction
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test70/test.canonical
+++ b/test/full_test70/test.canonical
@@ -156,7 +156,7 @@ do_end_critical
 marker 12
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -183,7 +183,7 @@ do_end_critical
 marker 14
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -208,7 +208,7 @@ do_end_critical
 marker 15
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -235,7 +235,7 @@ do_end_critical
 marker 17
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -261,7 +261,7 @@ do_end_critical
 marker 19
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -288,7 +288,7 @@ do_end_critical
 marker 21
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -331,7 +331,7 @@ do_end_critical
 marker 24
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -357,7 +357,7 @@ do_end_critical
 marker 26
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -400,7 +400,7 @@ do_end_critical
 marker 29
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 newMachine_subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 

--- a/test/full_test70/tl-actions.c
+++ b/test/full_test70/tl-actions.c
@@ -120,3 +120,9 @@ NEW_MACHINE_STATE __attribute__((weak)) UFMN(noTransitionFn)(pNEW_MACHINE pfsm, 
 	return pfsm->state;
 }
 
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
+}
+

--- a/test/full_test72/test.canonical
+++ b/test/full_test72/test.canonical
@@ -156,7 +156,7 @@ do_end_critical
 marker 12
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -183,7 +183,7 @@ do_end_critical
 marker 14
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -208,7 +208,7 @@ do_end_critical
 marker 15
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -235,7 +235,7 @@ do_end_critical
 marker 17
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -261,7 +261,7 @@ do_end_critical
 marker 19
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -288,7 +288,7 @@ do_end_critical
 marker 21
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -331,7 +331,7 @@ do_end_critical
 marker 24
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -357,7 +357,7 @@ do_end_critical
 marker 26
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 
@@ -400,7 +400,7 @@ do_end_critical
 marker 29
 do_start_critical
 event: newMachine_eShared; state: newMachine_s4
-weak: newMachine_shareSharedEvent
+newMachine_shareSharedEvent
 subMachine1_eShared_dt
 sub_machine1.data.cp: Good-bye, world.
 

--- a/test/full_test72/tl-actions.c
+++ b/test/full_test72/tl-actions.c
@@ -120,3 +120,9 @@ NEW_MACHINE_STATE __attribute__((weak)) UFMN(noTransitionFn)(pNEW_MACHINE pfsm, 
 	return pfsm->state;
 }
 
+NEW_MACHINE_EVENT_ENUM __attribute__((weak)) UFMN(shareSharedEvent)(pNEW_MACHINE pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	return newMachine_pass_shared_event(pfsm, sharing_newMachine_eShared);
+}
+

--- a/test/full_test73/sub-actions.c
+++ b/test/full_test73/sub-actions.c
@@ -20,3 +20,8 @@ void UFMN(onEntryTo_s2)(pSUB_DATA pdata)
 	printf("%s\n", __func__);
 }
 
+TEST_EVENT __attribute((weak)) UFMN(always)(FSM_TYPE_PTR pfsm)
+{
+	return sub_pass_shared_event(pfsm, sharing_sub_e1);
+}
+

--- a/test/full_test73/tf-actions.c
+++ b/test/full_test73/tf-actions.c
@@ -23,3 +23,8 @@ TEST_EVENT UFMN(noAction)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+TEST_EVENT __attribute((weak)) UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	return test_pass_shared_event(pfsm, sharing_test_e1);
+}
+

--- a/test/full_test8/test.canonical
+++ b/test/full_test8/test.canonical
@@ -13,4 +13,4 @@ newMachine_noAction
 newMachine_transitionFn1
 event: newMachine_e4; state: newMachine_s2
 newMachine_noAction
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test9/test.canonical
+++ b/test/full_test9/test.canonical
@@ -13,4 +13,4 @@ newMachine_noAction
 newMachine_transitionFn1
 event: newMachine_e4; state: newMachine_s2
 newMachine_noAction
-warning: cannot use external event designations
+Warning: Ignoring external event designations

--- a/test/full_test92/Makefile
+++ b/test/full_test92/Makefile
@@ -1,0 +1,20 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS +=                                   \
+			-DCOMPACT_DEBUG                             \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+         -I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+
+VARIANTS=cc
+
+include ../variants.mk
+
+

--- a/test/full_test92/c-actions.c
+++ b/test/full_test92/c-actions.c
@@ -1,0 +1,39 @@
+#include "compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(e4);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+int main(void)
+{
+	run_compact(THIS(e1));
+	run_compact(THIS(e2));
+	run_compact(THIS(e3));
+
+	return 0;
+}
+

--- a/test/full_test92/compact.fsm
+++ b/test/full_test92/compact.fsm
@@ -1,0 +1,41 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+*/
+machine compact
+{
+	event e1, e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	{
+		event parent::e1, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test92/sc-actions.c
+++ b/test/full_test92/sc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test92/ssc-actions.c
+++ b/test/full_test92/ssc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test92/test.canonical
+++ b/test/full_test92/test.canonical
@@ -1,0 +1,12 @@
+event: compact_e1; state: compact_s1
+compact_a1
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+event: compact_e2; state: compact_s2
+compact_a3
+event: compact_e4; state: compact_s1
+compact_noAction
+event: compact_e3; state: compact_s1
+compact_noAction

--- a/test/full_test93/Makefile
+++ b/test/full_test93/Makefile
@@ -1,0 +1,20 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS +=                                   \
+			-DCOMPACT_DEBUG                             \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+         -I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+
+VARIANTS=cc
+
+include ../variants.mk
+
+

--- a/test/full_test93/c-actions.c
+++ b/test/full_test93/c-actions.c
@@ -1,0 +1,62 @@
+#include "compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(e4);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+COMPACT_STATE compact_transition_to_s2(pCOMPACT pfsm,COMPACT_EVENT e)
+{
+	(void) pfsm;
+	(void) e;
+	DBG_PRINTF(__func__);
+	return STATE(s2);
+}
+
+COMPACT_STATE compact_transitionTos1(pCOMPACT pfsm,COMPACT_EVENT e)
+{
+	(void) pfsm;
+	(void) e;
+	DBG_PRINTF(__func__);
+	return STATE(s1);
+}
+
+COMPACT_STATE compact_noTransitionFn(pCOMPACT pfsm,COMPACT_EVENT e)
+{
+	(void) e;
+	DBG_PRINTF(__func__);
+	return pfsm->state;
+}
+
+int main(void)
+{
+	run_compact(THIS(e1));
+	run_compact(THIS(e2));
+	run_compact(THIS(e3));
+
+	return 0;
+}
+

--- a/test/full_test93/compact.fsm
+++ b/test/full_test93/compact.fsm
@@ -1,0 +1,43 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+
+ This adds transition functions to the mix.
+*/
+machine compact
+{
+	event e1, e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	{
+		event parent::e1, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition transition_to_s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test93/sc-actions.c
+++ b/test/full_test93/sc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test93/ssc-actions.c
+++ b/test/full_test93/ssc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test93/test.canonical
+++ b/test/full_test93/test.canonical
@@ -1,0 +1,16 @@
+event: compact_e1; state: compact_s1
+compact_a1
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+compact_transition_to_s2
+event: compact_e2; state: compact_s2
+compact_a3
+compact_transitionTos1
+event: compact_e4; state: compact_s1
+compact_noAction
+compact_noTransitionFn
+event: compact_e3; state: compact_s1
+compact_noAction
+compact_noTransitionFn

--- a/test/full_test94/Makefile
+++ b/test/full_test94/Makefile
@@ -1,0 +1,20 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS +=                                   \
+			-DCOMPACT_DEBUG                             \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+         -I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+
+VARIANTS=cc
+
+include ../variants.mk
+
+

--- a/test/full_test94/c-actions.c
+++ b/test/full_test94/c-actions.c
@@ -1,0 +1,62 @@
+#include "compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(e4);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+COMPACT_STATE UFMN(transition_to_s2)(pCOMPACT pfsm,COMPACT_EVENT e)
+{
+	(void) pfsm;
+	(void) e;
+	DBG_PRINTF(__func__);
+	return STATE(s2);
+}
+
+COMPACT_STATE UFMN(transitionTos1)(pCOMPACT pfsm,COMPACT_EVENT e)
+{
+	(void) pfsm;
+	(void) e;
+	DBG_PRINTF(__func__);
+	return STATE(s1);
+}
+
+COMPACT_STATE UFMN(noTransitionFn)(pCOMPACT pfsm,COMPACT_EVENT e)
+{
+	(void) e;
+	DBG_PRINTF(__func__);
+	return pfsm->state;
+}
+
+int main(void)
+{
+	run_compact(THIS(e1));
+	run_compact(THIS(e2));
+	run_compact(THIS(e3));
+
+	return 0;
+}
+

--- a/test/full_test94/compact.fsm
+++ b/test/full_test94/compact.fsm
@@ -1,0 +1,43 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+
+ This adds transition functions to the mix.
+*/
+machine compact
+{
+	event e1, e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	{
+		event parent::e1, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition transition_to_s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition transition_to_s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test94/sc-actions.c
+++ b/test/full_test94/sc-actions.c
@@ -1,0 +1,46 @@
+#include "sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+SUB_COMPACT_STATE UFMN(transition_to_s2)(FSM_TYPE_PTR pfsm,COMPACT_EVENT e)
+{
+	(void) pfsm;
+	(void) e;
+	DBG_PRINTF(__func__);
+	return STATE(s2);
+}
+
+SUB_COMPACT_STATE UFMN(transitionTos1)(FSM_TYPE_PTR pfsm,COMPACT_EVENT e)
+{
+	(void) pfsm;
+	(void) e;
+	DBG_PRINTF(__func__);
+	return STATE(s1);
+}
+
+SUB_COMPACT_STATE UFMN(noTransitionFn)(FSM_TYPE_PTR pfsm,COMPACT_EVENT e)
+{
+	(void) e;
+	DBG_PRINTF(__func__);
+	return pfsm->state;
+}
+

--- a/test/full_test94/ssc-actions.c
+++ b/test/full_test94/ssc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test94/test.canonical
+++ b/test/full_test94/test.canonical
@@ -1,0 +1,17 @@
+event: compact_e1; state: compact_s1
+compact_a1
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+compact_sub_compact_transition_to_s2
+compact_transition_to_s2
+event: compact_e2; state: compact_s2
+compact_a3
+compact_transitionTos1
+event: compact_e4; state: compact_s1
+compact_noAction
+compact_noTransitionFn
+event: compact_e3; state: compact_s1
+compact_noAction
+compact_noTransitionFn

--- a/test/full_test95/Makefile
+++ b/test/full_test95/Makefile
@@ -1,0 +1,20 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS +=                                   \
+			-DCOMPACT_DEBUG                             \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+         -I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+
+VARIANTS=cc
+
+include ../variants.mk
+
+

--- a/test/full_test95/c-actions.c
+++ b/test/full_test95/c-actions.c
@@ -1,0 +1,50 @@
+#include "compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(e4);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_translate_e1_data(pCOMPACT_DATA pfsm_data,pCOMPACT_E1_DATA pe_data)
+{
+	pfsm_data->e1_payload = pe_data->payload;
+}
+
+int main(void)
+{
+	COMPACT_EVENT event;
+
+	event.event_data.e1_data.payload = 1;
+	event.event = THIS(e1);
+	run_compact(&event);
+
+	event.event = THIS(e2);
+	run_compact(&event);
+
+	event.event = THIS(e3);
+	run_compact(&event);
+
+	return 0;
+}
+

--- a/test/full_test95/compact.fsm
+++ b/test/full_test95/compact.fsm
@@ -1,0 +1,53 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+*/
+machine compact
+native impl
+{
+#define INIT_FSM_DATA {.e1_payload = 0}
+}
+
+{
+
+data
+{
+	int e1_payload;
+}
+
+	event e1 data {int payload;};
+	event e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	{
+		event parent::e1, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test95/sc-actions.c
+++ b/test/full_test95/sc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test95/ssc-actions.c
+++ b/test/full_test95/ssc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test95/test.canonical
+++ b/test/full_test95/test.canonical
@@ -1,0 +1,12 @@
+event: compact_e1; state: compact_s1
+compact_a1
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+event: compact_e2; state: compact_s2
+compact_a3
+event: compact_e4; state: compact_s1
+compact_noAction
+event: compact_e3; state: compact_s1
+compact_noAction

--- a/test/full_test96/Makefile
+++ b/test/full_test96/Makefile
@@ -1,0 +1,20 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS +=                                   \
+			-DCOMPACT_DEBUG                             \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+         -I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+
+VARIANTS=cc
+
+include ../variants.mk
+
+

--- a/test/full_test96/c-actions.c
+++ b/test/full_test96/c-actions.c
@@ -1,0 +1,80 @@
+#include "compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(e4);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_translate_e1_data(pCOMPACT_DATA pfsm_data,pCOMPACT_E1_DATA pe_data)
+{
+	pfsm_data->e1_payload = pe_data->payload;
+}
+
+COMPACT_STATE compact_transition_to_s2(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) pfsm;
+	(void) e;
+
+	return STATE(s2);
+}
+
+COMPACT_STATE compact_transitionTos1(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) pfsm;
+	(void) e;
+
+	return STATE(s1);
+}
+
+COMPACT_STATE compact_noTransitionFn(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) e;
+
+	return pfsm->state;
+}
+
+
+int main(void)
+{
+	COMPACT_EVENT event;
+
+	event.event_data.e1_data.payload = 1;
+	event.event = THIS(e1);
+	run_compact(&event);
+
+	event.event = THIS(e2);
+	run_compact(&event);
+
+	event.event = THIS(e3);
+	run_compact(&event);
+
+	return 0;
+}
+

--- a/test/full_test96/compact.fsm
+++ b/test/full_test96/compact.fsm
@@ -1,0 +1,64 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+
+ This should work when the machines have data and have transition functions.
+*/
+machine compact
+native impl
+{
+#define INIT_FSM_DATA {.e1_payload = 0}
+}
+
+{
+
+	data
+	{
+		int e1_payload;
+	}
+
+	event e1 data {int payload;};
+	event e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	native impl
+	{
+	#define INIT_FSM_DATA {.e1_payload = 0}
+	}
+	{
+		data
+		{
+			int e1_payload;
+		}
+
+		event parent::e1 data translator grab_e1_data, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition transition_to_s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test96/sc-actions.c
+++ b/test/full_test96/sc-actions.c
@@ -1,0 +1,27 @@
+#include "sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(pfsm, sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(pfsm, sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_sub_compact_grab_e1_data(pCOMPACT_DATA pdata)
+{
+	DBG_PRINTF(__func__);
+	psub_compact->data.e1_payload = pdata->e1_payload;
+}
+

--- a/test/full_test96/ssc-actions.c
+++ b/test/full_test96/ssc-actions.c
@@ -1,0 +1,23 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+

--- a/test/full_test96/test.canonical
+++ b/test/full_test96/test.canonical
@@ -1,0 +1,17 @@
+event: compact_e1; state: compact_s1
+compact_a1
+compact_sub_compact_grab_e1_data
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+compact_transition_to_s2
+event: compact_e2; state: compact_s2
+compact_a3
+compact_transitionTos1
+event: compact_e4; state: compact_s1
+compact_noAction
+compact_noTransitionFn
+event: compact_e3; state: compact_s1
+compact_noAction
+compact_noTransitionFn

--- a/test/full_test97/Makefile
+++ b/test/full_test97/Makefile
@@ -1,0 +1,20 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS +=                                   \
+			-DCOMPACT_DEBUG                             \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+         -I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+
+VARIANTS=cc
+
+include ../variants.mk
+
+

--- a/test/full_test97/c-actions.c
+++ b/test/full_test97/c-actions.c
@@ -1,0 +1,95 @@
+#include "compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(e4);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_translate_e1_data(pCOMPACT_DATA pfsm_data,pCOMPACT_E1_DATA pe_data)
+{
+	pfsm_data->e1_payload = pe_data->payload;
+}
+
+COMPACT_STATE compact_transition_to_s2(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) pfsm;
+	(void) e;
+
+	return STATE(s2);
+}
+
+COMPACT_STATE compact_transitionTos1(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) pfsm;
+	(void) e;
+
+	return STATE(s1);
+}
+
+COMPACT_STATE compact_noTransitionFn(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) e;
+
+	return pfsm->state;
+}
+
+void UFMN(no_transition)(FSM_TYPE_PTR pfsm, COMPACT_STATE dest)
+{
+	DBG_PRINTF(__func__);
+	(void) pfsm;
+	(void) dest;
+}
+
+void UFMN(on_transition)(FSM_TYPE_PTR pfsm, COMPACT_STATE s)
+{
+	DBG_PRINTF(__func__);
+	DBG_PRINTF("from %s to %s"
+              , COMPACT_STATE_NAMES[pfsm->state]
+              , COMPACT_STATE_NAMES[s]
+				 );
+}
+
+int main(void)
+{
+	COMPACT_EVENT event;
+
+	event.event_data.e1_data.payload = 1;
+	event.event = THIS(e1);
+	run_compact(&event);
+
+	event.event = THIS(e2);
+	run_compact(&event);
+
+	event.event = THIS(e3);
+	run_compact(&event);
+
+	return 0;
+}
+

--- a/test/full_test97/compact.fsm
+++ b/test/full_test97/compact.fsm
@@ -1,0 +1,67 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+
+ This should work when the machines have data and have transition functions.
+*/
+machine compact
+on transition on_transition;
+native impl
+{
+#define INIT_FSM_DATA {.e1_payload = 0}
+}
+
+{
+
+	data
+	{
+		int e1_payload;
+	}
+
+	event e1 data {int payload;};
+	event e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	on transition on_transition;
+	native impl
+	{
+	#define INIT_FSM_DATA {.e1_payload = 0}
+	}
+	{
+		data
+		{
+			int e1_payload;
+		}
+
+		event parent::e1 data translator grab_e1_data, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		on transition on_transition;
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition transition_to_s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test97/sc-actions.c
+++ b/test/full_test97/sc-actions.c
@@ -1,0 +1,43 @@
+#include "sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(pfsm, sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(pfsm, sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_sub_compact_grab_e1_data(pCOMPACT_DATA pdata)
+{
+	DBG_PRINTF(__func__);
+	psub_compact->data.e1_payload = pdata->e1_payload;
+}
+
+void UFMN(no_transition)(FSM_TYPE_PTR pfsm, SUB_COMPACT_STATE dest)
+{
+	DBG_PRINTF(__func__);
+	(void) pfsm;
+	(void) dest;
+}
+
+void UFMN(on_transition)(FSM_TYPE_PTR pfsm, SUB_COMPACT_STATE s)
+{
+	DBG_PRINTF(__func__);
+	DBG_PRINTF("from %s to %s"
+              , SUB_COMPACT_STATE_NAMES[pfsm->state]
+              , SUB_COMPACT_STATE_NAMES[s]
+				 );
+}
+

--- a/test/full_test97/ssc-actions.c
+++ b/test/full_test97/ssc-actions.c
@@ -1,0 +1,39 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void UFMN(no_transition)(FSM_TYPE_PTR pfsm, SUB_SUB_COMPACT_STATE dest)
+{
+	DBG_PRINTF(__func__);
+	(void) pfsm;
+	(void) dest;
+}
+
+void UFMN(on_transition)(FSM_TYPE_PTR pfsm, SUB_SUB_COMPACT_STATE s)
+{
+	DBG_PRINTF(__func__);
+	DBG_PRINTF("from %s to %s"
+              , SUB_SUB_COMPACT_STATE_NAMES[pfsm->state]
+              , SUB_SUB_COMPACT_STATE_NAMES[s]
+				 );
+}
+

--- a/test/full_test97/test.canonical
+++ b/test/full_test97/test.canonical
@@ -1,0 +1,25 @@
+event: compact_e1; state: compact_s1
+compact_a1
+compact_sub_compact_grab_e1_data
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+compact_sub_compact_sub_sub_compact_on_transition
+from compact_sub_compact_sub_sub_compact_s1 to compact_sub_compact_sub_sub_compact_s2
+compact_sub_compact_on_transition
+from compact_sub_compact_s1 to compact_sub_compact_s2
+compact_transition_to_s2
+compact_on_transition
+from compact_s1 to compact_s2
+event: compact_e2; state: compact_s2
+compact_a3
+compact_transitionTos1
+compact_on_transition
+from compact_s2 to compact_s1
+event: compact_e4; state: compact_s1
+compact_noAction
+compact_noTransitionFn
+event: compact_e3; state: compact_s1
+compact_noAction
+compact_noTransitionFn

--- a/test/full_test98/Makefile
+++ b/test/full_test98/Makefile
@@ -1,0 +1,18 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -DCOMPACT_DEBUG                   \
+			-DCOMPACT_SUB_COMPACT_DEBUG                 \
+			-DCOMPACT_SUB_COMPACT_SUB_SUB_COMPACT_DEBUG \
+			-I../                                       \
+	 		-Wall                                       \
+	 		-ggdb
+
+override FSM_FLAGS+=--empty-cell-fn=i_am_empty
+
+include ../variants.mk
+
+

--- a/test/full_test98/c-actions.c
+++ b/test/full_test98/c-actions.c
@@ -28,6 +28,13 @@ ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
 void compact_translate_e1_data(pCOMPACT_DATA pfsm_data,pCOMPACT_E1_DATA pe_data)
 {
 	pfsm_data->e1_payload = pe_data->payload;

--- a/test/full_test98/c-actions.c
+++ b/test/full_test98/c-actions.c
@@ -1,0 +1,93 @@
+#include "compact_priv.h"
+
+#if defined(FSM_VARIANT_CC)
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a3)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return compact_pass_shared_event(pfsm,sharing_compact_e2); 
+}
+#endif
+
+ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_translate_e1_data(pCOMPACT_DATA pfsm_data,pCOMPACT_E1_DATA pe_data)
+{
+	pfsm_data->e1_payload = pe_data->payload;
+}
+
+COMPACT_STATE compact_transition_to_s2(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	DBG_PRINTF(__func__);
+
+	(void) pfsm;
+	(void) e;
+
+	return STATE(s2);
+}
+
+COMPACT_STATE compact_transitionTos1(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	(void) pfsm;
+	(void) e;
+
+	return STATE(s1);
+}
+
+COMPACT_STATE compact_noTransitionFn(pCOMPACT pfsm, COMPACT_EVENT_ENUM e)
+{
+	(void) e;
+
+	return pfsm->state;
+}
+
+void UFMN(no_transition)(FSM_TYPE_PTR pfsm, COMPACT_STATE dest)
+{
+	DBG_PRINTF(__func__);
+	(void) pfsm;
+	(void) dest;
+}
+
+void UFMN(on_transition)(FSM_TYPE_PTR pfsm, COMPACT_STATE s)
+{
+	DBG_PRINTF(__func__);
+	DBG_PRINTF("from %s to %s"
+              , COMPACT_STATE_NAMES[pfsm->state]
+              , COMPACT_STATE_NAMES[s]
+				 );
+}
+
+int main(void)
+{
+	COMPACT_EVENT event;
+
+	event.event_data.e1_data.payload = 1;
+	event.event = THIS(e1);
+	run_compact(&event);
+
+	event.event = THIS(e2);
+	run_compact(&event);
+
+	event.event = THIS(e3);
+	run_compact(&event);
+
+	return 0;
+}
+

--- a/test/full_test98/compact.fsm
+++ b/test/full_test98/compact.fsm
@@ -60,7 +60,6 @@ native impl
 
 	action a1[e1, s1] transition transition_to_s2;
 	action a2[e1, s2];
-	action a3[e2, s2] transition s1;
 	[e3, s2] transition s1;
 
 }

--- a/test/full_test98/compact.fsm
+++ b/test/full_test98/compact.fsm
@@ -1,0 +1,67 @@
+native
+{
+#include "test.h"
+}
+
+/*
+ C submachines should be able to be created with compact arrays.
+
+ This should work when the machines have data and have transition functions.
+*/
+machine compact
+on transition on_transition;
+native impl
+{
+#define INIT_FSM_DATA {.e1_payload = 0}
+}
+
+{
+
+	data
+	{
+		int e1_payload;
+	}
+
+	event e1 data {int payload;};
+	event e2, e3, e4;
+	state s1, s2;
+
+	machine sub_compact
+	on transition on_transition;
+	native impl
+	{
+	#define INIT_FSM_DATA {.e1_payload = 0}
+	}
+	{
+		data
+		{
+			int e1_payload;
+		}
+
+		event parent::e1 data translator grab_e1_data, parent::e2, parent::e3, e4;
+		state s1, s2;
+	
+		machine sub_sub_compact
+		on transition on_transition;
+		{
+			event parent::e1, parent::e2, parent::e3, e4;
+			state s1, s2;
+		
+			action a1[e1, s1] transition s2;
+			action a2[(e1, e2), s2];
+			[e3, s2] transition s1;
+		}
+
+		action a1[e1, s1] transition s2;
+		action a2[e1, s2];
+		action a2[e2, s2];
+		[e3, s2] transition s1;
+	}
+
+	action a1[e1, s1] transition transition_to_s2;
+	action a2[e1, s2];
+	action a3[e2, s2] transition s1;
+	[e3, s2] transition s1;
+
+}
+

--- a/test/full_test98/sc-actions.c
+++ b/test/full_test98/sc-actions.c
@@ -21,6 +21,13 @@ ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
 void compact_sub_compact_grab_e1_data(pCOMPACT_DATA pdata)
 {
 	DBG_PRINTF(__func__);

--- a/test/full_test98/sc-actions.c
+++ b/test/full_test98/sc-actions.c
@@ -1,0 +1,45 @@
+#include "sub_compact_priv.h"
+
+#if defined(FSM_VARIANT_CC)
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(pfsm, sharing_sub_compact_e1); 
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF(__func__);
+	return sub_compact_pass_shared_event(pfsm, sharing_sub_compact_e2); 
+}
+#endif
+
+ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void compact_sub_compact_grab_e1_data(pCOMPACT_DATA pdata)
+{
+	DBG_PRINTF(__func__);
+	psub_compact->data.e1_payload = pdata->e1_payload;
+}
+
+void UFMN(no_transition)(FSM_TYPE_PTR pfsm, SUB_COMPACT_STATE dest)
+{
+	DBG_PRINTF(__func__);
+	(void) pfsm;
+	(void) dest;
+}
+
+void UFMN(on_transition)(FSM_TYPE_PTR pfsm, SUB_COMPACT_STATE s)
+{
+	DBG_PRINTF(__func__);
+	DBG_PRINTF("from %s to %s"
+              , SUB_COMPACT_STATE_NAMES[pfsm->state]
+              , SUB_COMPACT_STATE_NAMES[s]
+				 );
+}
+

--- a/test/full_test98/ssc-actions.c
+++ b/test/full_test98/ssc-actions.c
@@ -21,6 +21,13 @@ ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
 	return THIS(noEvent);
 }
 
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
 void UFMN(no_transition)(FSM_TYPE_PTR pfsm, SUB_SUB_COMPACT_STATE dest)
 {
 	DBG_PRINTF(__func__);

--- a/test/full_test98/ssc-actions.c
+++ b/test/full_test98/ssc-actions.c
@@ -1,0 +1,39 @@
+#include "sub_sub_compact_priv.h"
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(a2)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+void UFMN(no_transition)(FSM_TYPE_PTR pfsm, SUB_SUB_COMPACT_STATE dest)
+{
+	DBG_PRINTF(__func__);
+	(void) pfsm;
+	(void) dest;
+}
+
+void UFMN(on_transition)(FSM_TYPE_PTR pfsm, SUB_SUB_COMPACT_STATE s)
+{
+	DBG_PRINTF(__func__);
+	DBG_PRINTF("from %s to %s"
+              , SUB_SUB_COMPACT_STATE_NAMES[pfsm->state]
+              , SUB_SUB_COMPACT_STATE_NAMES[s]
+				 );
+}
+

--- a/test/full_test98/test.canonical
+++ b/test/full_test98/test.canonical
@@ -1,0 +1,24 @@
+event: compact_e1; state: compact_s1
+compact_a1
+compact_sub_compact_grab_e1_data
+event: compact_sub_compact_e1; state: compact_sub_compact_s1
+compact_sub_compact_a1
+event: compact_sub_compact_sub_sub_compact_e1; state: compact_sub_compact_sub_sub_compact_s1
+compact_sub_compact_sub_sub_compact_a1
+compact_sub_compact_sub_sub_compact_on_transition
+from compact_sub_compact_sub_sub_compact_s1 to compact_sub_compact_sub_sub_compact_s2
+compact_sub_compact_on_transition
+from compact_sub_compact_s1 to compact_sub_compact_s2
+compact_transition_to_s2
+compact_on_transition
+from compact_s1 to compact_s2
+event: compact_e2; state: compact_s2
+compact_a3
+event: compact_sub_compact_e2; state: compact_sub_compact_s2
+compact_sub_compact_a2
+event: compact_sub_compact_sub_sub_compact_e2; state: compact_sub_compact_sub_sub_compact_s2
+compact_sub_compact_sub_sub_compact_a2
+compact_on_transition
+from compact_s2 to compact_s1
+event: compact_e3; state: compact_s1
+compact_i_am_empty

--- a/test/full_test98/test.canonical
+++ b/test/full_test98/test.canonical
@@ -13,12 +13,8 @@ compact_transition_to_s2
 compact_on_transition
 from compact_s1 to compact_s2
 event: compact_e2; state: compact_s2
-compact_a3
-event: compact_sub_compact_e2; state: compact_sub_compact_s2
-compact_sub_compact_a2
-event: compact_sub_compact_sub_sub_compact_e2; state: compact_sub_compact_sub_sub_compact_s2
-compact_sub_compact_sub_sub_compact_a2
+compact_i_am_empty
+event: compact_e3; state: compact_s2
+compact_noAction
 compact_on_transition
 from compact_s2 to compact_s1
-event: compact_e3; state: compact_s1
-compact_i_am_empty

--- a/test/full_test99/Makefile
+++ b/test/full_test99/Makefile
@@ -1,0 +1,16 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -DTEST_EMPTY_CELLS_DEBUG \
+			-I../                              \
+	 		-Wall                              \
+	 		-ggdb
+
+override FSM_FLAGS+=--empty-cell-fn=i_am_empty
+
+include ../variants.mk
+
+

--- a/test/full_test99/tec-actions.c
+++ b/test/full_test99/tec-actions.c
@@ -1,0 +1,49 @@
+#include "test_empty_cells_priv.h"
+
+#ifndef STATE
+#define STATE(A) test_empty_cells_#A
+#endif
+
+ACTION_RETURN_TYPE UFMN(a1)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(i_am_empty)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	(void) pfsm;
+	DBG_PRINTF(__func__);
+	return THIS(noEvent);
+}
+
+int main(void)
+{
+	run_test_empty_cells(THIS(e1));	//prints a1
+
+	ptest_empty_cells->state = STATE(s1);
+	run_test_empty_cells(THIS(e2));	//prints noAction
+
+	ptest_empty_cells->state = STATE(s1);
+	run_test_empty_cells(THIS(e3));	//prints i_am_empty
+
+	ptest_empty_cells->state = STATE(s2);
+	run_test_empty_cells(THIS(e1));	//prints i_am_empty
+
+	ptest_empty_cells->state = STATE(s2);
+	run_test_empty_cells(THIS(e2));	//prints i_am_empty
+
+	ptest_empty_cells->state = STATE(s2);
+	run_test_empty_cells(THIS(e3));	//prints i_am_empty
+
+	return 0;
+}
+

--- a/test/full_test99/test.canonical
+++ b/test/full_test99/test.canonical
@@ -1,0 +1,12 @@
+event: test_empty_cells_e1; state: test_empty_cells_s1
+test_empty_cells_a1
+event: test_empty_cells_e2; state: test_empty_cells_s1
+test_empty_cells_noAction
+event: test_empty_cells_e3; state: test_empty_cells_s1
+test_empty_cells_i_am_empty
+event: test_empty_cells_e1; state: test_empty_cells_s2
+test_empty_cells_i_am_empty
+event: test_empty_cells_e2; state: test_empty_cells_s2
+test_empty_cells_i_am_empty
+event: test_empty_cells_e3; state: test_empty_cells_s2
+test_empty_cells_i_am_empty

--- a/test/full_test99/test_empty_cells.fsm
+++ b/test/full_test99/test_empty_cells.fsm
@@ -1,0 +1,26 @@
+native
+{
+#include "test.h"
+}
+
+/*
+	The new --empty-cell-fn=<fn_name> should result in fn_name being
+		called iff there is no action or transition for a given
+		event/state cell.
+
+	Action a1 is defined in e1,s1.
+	A transition is defined in e2, s1.
+
+	All other cells are empty.
+*/
+machine test_empty_cells
+{
+
+	event e1, e2, e3;
+	state s1, s2;
+
+	action a1[e1, s1];
+	[e2, s1] transition s2;
+
+}
+

--- a/test/variants.mk
+++ b/test/variants.mk
@@ -1,4 +1,4 @@
-VARIANTS ?= c s e
+VARIANTS ?= c s e cc
 
 .PHONY: runtest test clean clean_generated $(VARIANTS)
 
@@ -12,6 +12,9 @@ c c.size c_run: CFLAGS+=-DFSM_VARIANT_C
 #s s.size s_run: FSM_FLAGS=-ts
 s s.size s_run: FSM_FLAGS+=-ts --generate-weak-fns=false --force-generation-of-event-passing-actions
 s s.size s_run: CFLAGS+=-DFSM_VARIANT_S
+
+cc cc.size cc_run: FSM_FLAGS+=-tc -c --generate-weak-fns=false
+cc cc.size cc_run: CFLAGS+=-DFSM_VARIANT_CC
 
 runtest: $(addsuffix _run, $(VARIANTS))
 	@echo "all tests successful"
@@ -30,7 +33,7 @@ $(addsuffix .size, $(VARIANTS)):
 	@$(MAKE) -f ../create_target.mk FSM_FLAGS="$(FSM_FLAGS)" clean
 
 $(addsuffix _run, $(VARIANTS)):
-	@echo $(FSM_FLAGS)
+	@echo $@: $(FSM_FLAGS)
 	@$(MAKE) -f ../create_target.mk FSM_FLAGS="$(FSM_FLAGS)" CFLAGS="$(CFLAGS)" do_runtest
 
 clean:


### PR DESCRIPTION
This PR corrects errors preventing the -c command line switch from working with sub machines.

It also implements a new feature, requested by a user, to allow the designation of a function to be called when the state machine encounters an empty event/state cell.