### PR TITLE
use correct event parentage when constructing anchors and references.

### DIFF
--- a/src/fsm_rst.c
+++ b/src/fsm_rst.c
@@ -122,6 +122,7 @@ static FSMRSTOutputGenerator RSTMachineWriter = {
      closeRSTWriter,
 	   generateRSTMachineWriter 
   },
+  NULL,
   NULL
 };
 


### PR DESCRIPTION
The RST generator is now aware of parent machines and also inspects event records to find the owning machine when constructing names and references.