### PR TITLE
Bump to revision 1.46.

### DIFF
--- a/src/revision.c
+++ b/src/revision.c
@@ -437,12 +437,18 @@
 	existence of these alternative formats is unpublished and
 	undocumented.
 
-	Move the <i>usage</i> function to its own file.
+	Move the usage function to its own file.
 
 	Add an option to include state enumerations in the cross-reference only
 	output.
 
 	Create a complete example of a hierarchical state machine.
+
+	Do not share events in states which inhibit sub-machines.  A new CL option,
+
+		--inhibiting-states-share-events=<*true|false>
+
+	has been added to preserve the previous behavior, which was to share events.
 
 */
 const char rev_string[] = "1.46";

--- a/src/revision.c
+++ b/src/revision.c
@@ -427,5 +427,23 @@
 	Also, removes _events.h files for sub-machines, since they are
 	empty.
 */
-const char rev_string[] = "1.45.1";
+
+/*
+	Revision 1.46
+
+	Include stdbool.h when functions returning bool are generated.
+
+	Add RST as an opton to alternative output format for -h.  The
+	existence of these alternative formats is unpublished and
+	undocumented.
+
+	Move the <i>usage</i> function to its own file.
+
+	Add an option to include state enumerations in the cross-reference only
+	output.
+
+	Create a complete example of a hierarchical state machine.
+
+*/
+const char rev_string[] = "1.46";
 

--- a/test/full_test26/test.canonical
+++ b/test/full_test26/test.canonical
@@ -1,6 +1,6 @@
 Hello, world.
 
-FSM version: 1.45.1
+FSM version: 1.46
 
 event: top_level_e1; state: top_level_s1
 event: top_level_e2; state: top_level_s2

--- a/test/full_test27/test.canonical
+++ b/test/full_test27/test.canonical
@@ -1,6 +1,6 @@
 Hello, world.
 
-FSM version: 1.45.1
+FSM version: 1.46
 
 event: top_level_e1; state: top_level_s1
 top_level_a1

--- a/test/full_test28/test.canonical
+++ b/test/full_test28/test.canonical
@@ -1,6 +1,6 @@
 Hello, world.
 
-FSM version: 1.45.1
+FSM version: 1.46
 
 event: top_level_e1; state: top_level_s1
 top_level_a1


### PR DESCRIPTION
Update revision.c with release comments and new revision string.

Update canonical output files containing the revision string.