### PR TITLE
Correcting behavior of machines with actions returning void or states when events have data.

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -3295,7 +3295,9 @@ void printFSMMachineDebugBlock(pCMachineData pcmd, pMACHINE_INFO pmi)
 
     fprintf(pcmd->cFile
             , "if (EVENT_IS_NOT_EXCLUDED_FROM_LOG(%s))\n{\n"
-            , (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
+			, ((pmi->modFlags & ACTIONS_RETURN_FLAGS) && (pmi->data_block_count == 0))
+			  ? "event" 
+			  : "e"
             );
     if (short_dbg_names && add_machine_name)
     {
@@ -3311,7 +3313,9 @@ void printFSMMachineDebugBlock(pCMachineData pcmd, pMACHINE_INFO pmi)
     fprintf(pcmd->cFile
             , "%s_EVENT_NAMES[%s]\n,%s_STATE_NAMES[pfsm->state]\n);\n}\n#endif\n\n"
 			, ucMachineName(pcmd)
-            , (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
+			, ((pmi->modFlags & ACTIONS_RETURN_FLAGS) && (pmi->data_block_count == 0))
+			  ? "event" 
+			  : "e"
 			, ucMachineName(pcmd)
            );
 
@@ -3325,12 +3329,12 @@ void printFSMSubMachineDebugBlock(pCMachineData pcmd, pMACHINE_INFO pmi)
 			);
 	fprintf(pcmd->cFile
 			, "if ((EVENT_IS_NOT_EXCLUDED_FROM_LOG(%s))\n"
-			, (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
+			, (pmi->modFlags & ACTIONS_RETURN_FLAGS) ? "event" : "e"
 			);
 	fprintf(pcmd->cFile
 			, "    && (%s >= THIS(firstEvent))\n    && (%s < THIS(noEvent))\n   )\n{\n"
-			, (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
-			, (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
+			, (pmi->modFlags & ACTIONS_RETURN_FLAGS) ? "event" : "e"
+			, (pmi->modFlags & ACTIONS_RETURN_FLAGS) ? "event" : "e"
 			);
 
     fprintf(pcmd->cFile, "\tDBG_PRINTF(\"");
@@ -3347,7 +3351,7 @@ void printFSMSubMachineDebugBlock(pCMachineData pcmd, pMACHINE_INFO pmi)
     fprintf(pcmd->cFile
 			, "%s_EVENT_NAMES[%s - THIS(firstEvent)]\n,%s_STATE_NAMES[pfsm->state]\n);\n}\n#endif\n\n"
 			, ucMachineName(pcmd)
-			, (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
+			, (pmi->modFlags & ACTIONS_RETURN_FLAGS) ? "event" : "e"
 			, ucMachineName(pcmd)
 			);
 

--- a/src/fsm_c_event_table.c
+++ b/src/fsm_c_event_table.c
@@ -1323,6 +1323,13 @@ static void defineCEventTableMachineFSM(pFSMCOutputGenerator pfsmcog)
               , pmi->data_block_count ? "->event" : ""
              );
    }
+   else if (pmi->data_block_count != 0)
+   {
+	   fprintf(pcmd->cFile
+			   , "\t%s_EVENT_ENUM e = event->event;\n\n"
+			   , ucfqMachineName(pcmd)
+			   );
+   }
 
    if (add_profiling_macros)
    {
@@ -1370,8 +1377,9 @@ static void writeEventTableFSMLoopInnards(pFSMCOutputGenerator pfsmcog, char *ta
 	if (pmi->modFlags & mfActionsReturnVoid)
 	{
 	   fprintf(pcmd->cFile
-			   , "%s\t((* (*pfsm->eventsArray)[event])(pfsm));\n"
+			   , "%s\t((* (*pfsm->eventsArray)[%s])(pfsm));\n"
 			   , tabstr
+			   , (pmi->data_block_count == 0) ? "event" : "e"
 			   );
 	}
 	else
@@ -1436,15 +1444,23 @@ static void writeActionsReturnStateEventTableFSM(pFSMCOutputGenerator pfsmcog)
              : ""
            );
 
+   fprintf(pcmd->cFile
+		   , "\n#ifdef %s_DEBUG\n"
+		   , fsmType(pcmd)
+		   );
    fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"event: %%s; start state: %%s\"\n\t\t,");
    fprintf(pcmd->cFile
-           , "%s_EVENT_NAMES[event]\n\t\t,"
+           , "%s_EVENT_NAMES[%s]\n\t\t,"
            , ucfqMachineName(pcmd)
+		   , pmi->data_block_count ? "e" : "event"
            );
    fprintf(pcmd->cFile
            , "%s_STATE_NAMES[pfsm->state]\n\t\t);\n\n"
            , ucnfMachineName(pcmd)
            );
+   fprintf(pcmd->cFile
+		   , "\n#endif\n"
+		   );
 
    if (pmi->data_block_count)
    {
@@ -1461,8 +1477,9 @@ static void writeActionsReturnStateEventTableFSM(pFSMCOutputGenerator pfsmcog)
    }
 
    fprintf(pcmd->cFile
-           , "\t%ss = ((* (*pfsm->eventsArray)[event])(pfsm));\n\n"
+           , "\t%ss = ((* (*pfsm->eventsArray)[%s])(pfsm));\n\n"
            , tabstr
+		   , pmi->data_block_count ? "e" : "event"
            );
 
    if (add_profiling_macros)
@@ -1516,11 +1533,18 @@ static void writeActionsReturnStateEventTableFSM(pFSMCOutputGenerator pfsmcog)
            , "\t\tpfsm->state = s;\n\t}\n\n"
           );
 
+   fprintf(pcmd->cFile
+		   , "\n#ifdef %s_DEBUG\n"
+		   , fsmType(pcmd)
+		   );
    fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"end state: %%s\"\n\t\t,");
    fprintf(pcmd->cFile
            , "%s_STATE_NAMES[pfsm->state]\n\t\t);\n"
            , ucnfMachineName(pcmd)
            );
+   fprintf(pcmd->cFile
+		   , "\n#endif\n"
+		   );
 
 }
 

--- a/src/fsm_c_switch_common.c
+++ b/src/fsm_c_switch_common.c
@@ -224,13 +224,14 @@ void writeOriginalSwitchFSMLoopArv(pFSMCOutputGenerator pfsmcog)
            );
    fprintf(pcmd->cFile
            , "\t\tpfsm->event = %s;\n\n"
-           , (pmi->modFlags & mfActionsReturnVoid) ? "event" : "e"
+		   , (pmi->data_block_count == 0) ? "event" : "e"
            );
 
    if (pmi->machine_list)
    {
       fprintf(pcmd->cFile
-              , "\t\tif (e < %s_noEvent)\n\t\t{\n"
+              , "\t\tif (%s < %s_noEvent)\n\t\t{\n"
+			  , (pmi->data_block_count == 0) ? "event" : "e"
               , pmi->name->name
               );
       tabstr = "\t\t";

--- a/test/full_test74/Makefile
+++ b/test/full_test74/Makefile
@@ -1,0 +1,15 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -I../ \
+	 -Wall \
+	 -ggdb
+
+VARIANTS=c s e
+
+include ../variants.mk
+
+

--- a/test/full_test74/test.c
+++ b/test/full_test74/test.c
@@ -1,0 +1,15 @@
+#include "test_fsm.h"
+
+int main(void)
+{
+	TEST_FSM_EVENT e;
+
+	e.event = THIS(e1);
+	e.event_data.e1_data.i = 1;
+	run_test_fsm(&e);
+	run_test_fsm(&e);
+	run_test_fsm(&e);
+	run_test_fsm(&e);
+
+	return 0;
+}

--- a/test/full_test74/test.canonical
+++ b/test/full_test74/test.canonical
@@ -1,0 +1,12 @@
+test_fsm_grab_e1_data
+e1 accumulator: 1
+test_fsm_handle_e1
+test_fsm_grab_e1_data
+e1 accumulator: 2
+test_fsm_handle_e1
+test_fsm_grab_e1_data
+e1 accumulator: 3
+test_fsm_handle_e1
+test_fsm_grab_e1_data
+e1 accumulator: 4
+test_fsm_handle_e1

--- a/test/full_test74/test_fsm-actions.c
+++ b/test/full_test74/test_fsm-actions.c
@@ -1,0 +1,25 @@
+#include "test_fsm_priv.h"
+
+void UFMN(handle_e1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+}
+
+void UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+
+}
+
+void test_fsm_grab_e1_data(pTEST_FSM_DATA pfsm_data,pTEST_FSM_E1_DATA pdata)
+{
+	DBG_PRINTF("%s", __func__);
+
+	pfsm_data->e1_count += pdata->i;
+
+	DBG_PRINTF("e1 accumulator: %u", pfsm_data->e1_count);
+
+}
+

--- a/test/full_test74/test_fsm.fsm
+++ b/test/full_test74/test_fsm.fsm
@@ -1,0 +1,22 @@
+native
+{
+#include "test.h"
+#define INIT_FSM_DATA { .e1_count = 0 }
+}
+
+machine test_fsm
+	actions return void;
+{
+	data
+	{
+		int e1_count;
+	}
+
+	event e1 data translator grab_e1_data {int i;};
+
+	state s1;
+
+	action handle_e1[e1, s1];
+
+}
+

--- a/test/full_test75/Makefile
+++ b/test/full_test75/Makefile
@@ -1,0 +1,15 @@
+##########################################
+#
+# makefile for individual test
+#
+#
+
+override CFLAGS += -I../ \
+	 -Wall \
+	 -ggdb
+
+VARIANTS=c s e
+
+include ../variants.mk
+
+

--- a/test/full_test75/test.c
+++ b/test/full_test75/test.c
@@ -1,0 +1,15 @@
+#include "test_fsm.h"
+
+int main(void)
+{
+	TEST_FSM_EVENT e;
+
+	e.event = THIS(e1);
+	e.event_data.e1_data.i = 1;
+	run_test_fsm(&e);
+	run_test_fsm(&e);
+	run_test_fsm(&e);
+	run_test_fsm(&e);
+
+	return 0;
+}

--- a/test/full_test75/test.canonical
+++ b/test/full_test75/test.canonical
@@ -1,0 +1,12 @@
+test_fsm_grab_e1_data
+e1 accumulator: 1
+test_fsm_handle_e1
+test_fsm_grab_e1_data
+e1 accumulator: 2
+test_fsm_handle_e1
+test_fsm_grab_e1_data
+e1 accumulator: 3
+test_fsm_handle_e1
+test_fsm_grab_e1_data
+e1 accumulator: 4
+test_fsm_handle_e1

--- a/test/full_test75/test_fsm-actions.c
+++ b/test/full_test75/test_fsm-actions.c
@@ -1,0 +1,28 @@
+#include "test_fsm_priv.h"
+
+TEST_FSM_STATE UFMN(handle_e1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+
+	return STATE(noTransition);
+}
+
+TEST_FSM_STATE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+
+	return STATE(noTransition);
+}
+
+void test_fsm_grab_e1_data(pTEST_FSM_DATA pfsm_data,pTEST_FSM_E1_DATA pdata)
+{
+	DBG_PRINTF("%s", __func__);
+
+	pfsm_data->e1_count += pdata->i;
+
+	DBG_PRINTF("e1 accumulator: %u", pfsm_data->e1_count);
+
+}
+

--- a/test/full_test75/test_fsm.fsm
+++ b/test/full_test75/test_fsm.fsm
@@ -1,0 +1,22 @@
+native
+{
+#include "test.h"
+#define INIT_FSM_DATA { .e1_count = 0 }
+}
+
+machine test_fsm
+	actions return states;
+{
+	data
+	{
+		int e1_count;
+	}
+
+	event e1 data translator grab_e1_data {int i;};
+
+	state s1;
+
+	action handle_e1[e1, s1];
+
+}
+

--- a/test/variants.mk
+++ b/test/variants.mk
@@ -44,7 +44,7 @@ clean_generated:
 	@$(MAKE) -f ../create_target.mk FSM_FLAGS="$(FSM_FLAGS)" clean
 
 $(VARIANTS):
-	$(MAKE) -f ../create_target.mk FSM_FLAGS="$(FSM_FLAGS)" VARIANTS="$(VARIANTS)" $@
+	$(MAKE) -f ../create_target.mk FSM_FLAGS="$(FSM_FLAGS)" VARIANTS="$@" $@
 
 stats.txt:
 	$(MAKE) -f ../create_target.mk $@


### PR DESCRIPTION
Single layer machines now behave correctly.

Error in variants.mk (passing wrong dfn of VARIANTS when calling recursively) fixed.