### PR TITLE
Define the _DEBUG protection macro consistently in sub-machine files.

### DIFF
--- a/src/fsm_c.c
+++ b/src/fsm_c.c
@@ -759,7 +759,7 @@ static void writeActionsReturnStateSubFSM(pFSMCOutputGenerator pfsmcog)
 
 	fprintf(pcmd->cFile
 			, "\n#ifdef %s_DEBUG\n"
-			, fsmType(pcmd)
+			, ucfqMachineName(pcmd)
 			);
 	fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"event: %%s; start state: %%s\"\n\t\t,");
 	fprintf(pcmd->cFile
@@ -846,7 +846,7 @@ static void writeActionsReturnStateSubFSM(pFSMCOutputGenerator pfsmcog)
 
 	fprintf(pcmd->cFile
 			, "\n#ifdef %s_DEBUG\n"
-			, fsmType(pcmd)
+			, ucfqMachineName(pcmd)
 			);
 	fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"end state: %%s\"\n\t\t,");
 	fprintf(pcmd->cFile

--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -2839,7 +2839,7 @@ void subMachineHeaderStart(pFSMCOutputGenerator pfsmcog
 
    fprintf(pcmd->hFile
 		   , "#ifdef %s_DEBUG\n"
-		   , fsmType(pcmd)
+		   , ucfqMachineName(pcmd)
 		   );
    fprintf(pcmd->hFile, "#include <stdio.h>\n");
    fprintf(pcmd->hFile, "#include <stdlib.h>\n");

--- a/src/fsm_c_event_table.c
+++ b/src/fsm_c_event_table.c
@@ -1640,7 +1640,7 @@ static void writeActionsReturnStateEventTableSubFSM(pFSMCOutputGenerator pfsmcog
 
 	fprintf(pcmd->cFile
 			, "\n#ifdef %s_DEBUG\n"
-			, fsmType(pcmd)
+			, ucfqMachineName(pcmd)
 			);
 	fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"event: %%s; start state: %%s\"\n\t\t,");
 	fprintf(pcmd->cFile
@@ -1764,7 +1764,7 @@ static void writeActionsReturnStateEventTableSubFSM(pFSMCOutputGenerator pfsmcog
 
 	fprintf(pcmd->cFile
 			, "\n#ifdef %s_DEBUG\n"
-			, fsmType(pcmd)
+			, ucfqMachineName(pcmd)
 			);
 	fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"end state: %%s\"\n\t\t,");
 	fprintf(pcmd->cFile

--- a/src/fsm_c_single_switch.c
+++ b/src/fsm_c_single_switch.c
@@ -526,7 +526,7 @@ static void defineCSingleSwitchMachineFSM(pFSMCOutputGenerator pfsmcog)
    {
 	   fprintf(pcmd->cFile
 			   , "\n#ifdef %s_DEBUG\n"
-			   , fsmType(pcmd)
+			   , ucfqMachineName(pcmd)
 			  );
 	   fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"end state: %%s\"\n\t\t,");
 	   fprintf(pcmd->cFile

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -298,7 +298,7 @@ static void writeActionsReturnStateSwitchSubFSM(pFSMCOutputGenerator pfsmcog)
 
    fprintf(pcmd->cFile
 		   , "\n#ifdef %s_DEBUG\n"
-		   , fsmType(pcmd)
+		   , ucfqMachineName(pcmd)
 		   );
    fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"event: %%s; start state: %%s\"\n\t\t,");
    fprintf(pcmd->cFile
@@ -415,7 +415,7 @@ static void writeActionsReturnStateSwitchSubFSM(pFSMCOutputGenerator pfsmcog)
 
    fprintf(pcmd->cFile
 		   , "\n#ifdef %s_DEBUG\n"
-		   , fsmType(pcmd)
+		   , ucfqMachineName(pcmd)
 		   );
    fprintf(pcmd->cFile, "\n\tDBG_PRINTF(\"end state: %%s\"\n\t\t,");
    fprintf(pcmd->cFile


### PR DESCRIPTION
Bug author had requested moving one instance of the macro to the short-name version; however, there were many more instances using the fully qualified name.  So, this solution standardizes on that for sub-machine files.