### PR TITLE
283 update release workflow to publish a package suitable for cmake fetchcontent

### DIFF
--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -156,8 +156,6 @@ jobs:
             URL https://github.com/FSMLang/FSMLang/releases/download/<TAG>/fsm-<TAG>-linux-cmake-src.tar.gz
           )
           FetchContent_MakeAvailable(fsmlang_tools)
-
-          add_subdirectory(${fsmlang_tools_SOURCE_DIR} fsmlang_tools)
           ```
 
           Then run:

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -277,7 +277,7 @@ Then run:
           name: fsm-${{ needs.resolve-upload-url.outputs.tag }}-windows-cmake-src.tar.gz.sha256
           path: artifacts/
 
-      - name: Create GPG detached signatures for Linux artifacts (only if signing)
+      - name: Create GPG detached signatures for Windows artifacts (only if signing)
         if: ${{ steps.check_signing.outputs.sign == 'true' }}
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
- [x] Investigate the review comments
- [x] Fix FetchContent example in release_linux.yml (remove duplicate add_subdirectory call)
- [x] Fix FetchContent example in release_windows.yml (remove duplicate add_subdirectory call) - already done in prior commit
- [x] Fix step name in release_windows.yml (Linux → Windows artifacts)

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.