### PR TITLE
313 prevent machines having state returning actions from having an action   transition matrix declaration

### DIFF
--- a/fsmrules.mk
+++ b/fsmrules.mk
@@ -23,11 +23,11 @@ ifeq ($(TARGET),fsm_fail_is_pass)
 CALL_FSM_FAILURE_A_SUCCESS = ; if [ $$? -ne 0 ]; then echo "expected fsm failure; test passes"; true; else echo "did not find an expected fsm failure; test fails"; false; fi
 endif
 
-GENERATED_SRC      = $(shell $(FSM) -M $(FSM_FLAGS) $(FSM_SRC))
-GENERATED_HDR      = $(shell $(FSM) -Mh $(FSM_FLAGS) $(FSM_SRC))
-GENERATED_HTML     = $(shell $(FSM) -th -M $(FSM_HTML_FLAGS) $(FSM_SRC))
-GENERATED_PLANTUML = $(shell $(FSM) -tp -M $(FSM_PLANTUML_FLAGS) $(FSM_SRC))
-GENERATED_RST      = $(shell $(FSM) -M -tr $(FSM_SRC))
+GENERATED_SRC      = $(shell $(FSM) -M $(FSM_FLAGS) $(FSM_SRC) 2>> fsmout)
+GENERATED_HDR      = $(shell $(FSM) -Mh $(FSM_FLAGS) $(FSM_SRC) 2>> fsmout)
+GENERATED_HTML     = $(shell $(FSM) -th -M $(FSM_HTML_FLAGS) $(FSM_SRC) 2>> fsmout)
+GENERATED_PLANTUML = $(shell $(FSM) -tp -M $(FSM_PLANTUML_FLAGS) $(FSM_SRC) 2>> fsmout)
+GENERATED_RST      = $(shell $(FSM) -M -tr $(FSM_SRC) 2>> fsmout)
 
 cleanfsm:
 	@-rm -f $(GENERATED_SRC) 2> /dev/null
@@ -79,15 +79,20 @@ $(SRC): $(FSM_SRC:.fsm=.h)
 	@set -e; $(FSM) -tr -Md $(FSM_RST_FLAGS) $< > $@
 
 ifneq ($(TARGET),fsm_fail_is_pass)
+
 ifneq ($(MAKECMDGOALS),clean)
+
 ifdef FSM_PLANTUML_FLAGS
 -include $(FSM_SRC:.fsm=.fsmdp)
 endif
+
 ifdef FSM_HTML_FLAGS
 -include $(FSM_SRC:.fsm=.fsmdh)
 endif
+
 -include $(FSM_SRC:.fsm=.fsmd)
 -include $(FSM_SRC:.fsm=.fsmdr)
 endif
+
 endif
 

--- a/fsmrules.mk
+++ b/fsmrules.mk
@@ -23,11 +23,11 @@ ifeq ($(TARGET),fsm_fail_is_pass)
 CALL_FSM_FAILURE_A_SUCCESS = ; if [ $$? -ne 0 ]; then echo "expected fsm failure; test passes"; true; else echo "did not find an expected fsm failure; test fails"; false; fi
 endif
 
-GENERATED_SRC      = $(shell $(FSM) -M $(FSM_FLAGS) $(FSM_SRC) 2>> fsmout)
-GENERATED_HDR      = $(shell $(FSM) -Mh $(FSM_FLAGS) $(FSM_SRC) 2>> fsmout)
-GENERATED_HTML     = $(shell $(FSM) -th -M $(FSM_HTML_FLAGS) $(FSM_SRC) 2>> fsmout)
-GENERATED_PLANTUML = $(shell $(FSM) -tp -M $(FSM_PLANTUML_FLAGS) $(FSM_SRC) 2>> fsmout)
-GENERATED_RST      = $(shell $(FSM) -M -tr $(FSM_SRC) 2>> fsmout)
+GENERATED_SRC      = $(shell $(FSM) -M $(FSM_FLAGS) $(FSM_SRC))
+GENERATED_HDR      = $(shell $(FSM) -Mh $(FSM_FLAGS) $(FSM_SRC))
+GENERATED_HTML     = $(shell $(FSM) -th -M $(FSM_HTML_FLAGS) $(FSM_SRC))
+GENERATED_PLANTUML = $(shell $(FSM) -tp -M $(FSM_PLANTUML_FLAGS) $(FSM_SRC))
+GENERATED_RST      = $(shell $(FSM) -M -tr $(FSM_SRC))
 
 cleanfsm:
 	@-rm -f $(GENERATED_SRC) 2> /dev/null

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -1720,10 +1720,7 @@ static bool print_state_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
                     }
 
                     fprintf(pich->pcmd->cFile
-                            , "\t\t%s UFMN(%s)(pfsm);\n"
-							, pai->transition
-							  ? "(void)"
-							  : "retVal ="
+                            , "\t\tretVal = UFMN(%s)(pfsm);\n"
                             , pai->action->name
                             );
 
@@ -1735,8 +1732,7 @@ static bool print_state_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
                     }
 
                 }
-
-				if (pai->transition)
+				else if (pai->transition)
 				{
                    fprintf(pich->pcmd->cFile
                            , "\t\tretVal = %s(%s)%s;\n"

--- a/src/parser.y
+++ b/src/parser.y
@@ -267,6 +267,7 @@ machine:	machine_prefix ID machine_qualifier
 						pid_state->powningMachine = pmachineInfo;
 						pid_state->order          = NO_TRANSITION;  // This makes it easier to detect.
 
+					pmachineInfo->modFlags |= $3->modFlags;
          } 
         '{' statement_decl_list '}'
 					{
@@ -278,7 +279,6 @@ machine:	machine_prefix ID machine_qualifier
  			      $$->machineTransition  = $3->machineTransition;
             $$->native_impl_prologue = $3->native_impl_prologue;
             $$->native_impl_epilogue = $3->native_impl_epilogue;
-
 
 						/* harvest the lists */
  					$$->data               = $6->data;
@@ -367,6 +367,8 @@ machine:	machine_prefix ID machine_qualifier
 
             add_id(id_list,MACHINE,$2->name,&pid);
             pid->powningMachine = $$;
+
+						pmachineInfo = $$->parent;
 
            }
 
@@ -1269,6 +1271,10 @@ action: action_matrix
 					}
 	| action_matrix transition 	
 					{
+						if (pmachineInfo->modFlags & mfActionsReturnStates)
+						{
+							yyerror("Cannot have actions with transitions when actions return states.");
+						}
 
 						#ifdef PARSER_DEBUG
 						fprintf(yyout,"found an action with transition\n");

--- a/test/full_test131/Makefile
+++ b/test/full_test131/Makefile
@@ -4,16 +4,20 @@
 #
 #
 
+.PHONEY: clean
+
 override CFLAGS += -I../ \
 	 -Wall \
-	 -ggdb
+	 -ggdb \
+    -DTEST_FSM_DEBUG
 
 
-VARIANTS=s sc
+TARGET=fsm_fail_is_pass
 
-DIFF_FLAGS= -I \"warning: (test_fsm_sub_subSub): all events are handled identically in all states\\.\"  \
-            -I \"warning: (test_fsm_sub2_subSub): all events are handled identically in all states\\.\" 
-
-include ../variants.mk
-
+ifneq ($(MAKECMDGOALS),clean)
+include ../../fsmrules.mk
+include ../test.mk
+else
+clean:
+endif
 

--- a/test/full_test131/Makefile
+++ b/test/full_test131/Makefile
@@ -4,7 +4,7 @@
 #
 #
 
-.PHONEY: clean
+.PHONY: clean
 
 override CFLAGS += -I../ \
 	 -Wall \

--- a/test/full_test132/sub.fsms
+++ b/test/full_test132/sub.fsms
@@ -16,6 +16,6 @@
 
 		include subSub.fsms
 
-		action do_nothing[e1, s1] transition s2;
-		action do_nothing[e1, s2] transition s1;
+		action do_nothing[e1, s1];
+		action do_nothing[e1, s2];
 	}

--- a/test/full_test132/sub2.fsms
+++ b/test/full_test132/sub2.fsms
@@ -15,6 +15,6 @@
 
 		include subSub.fsms
 
-		action do_nothing[e1, s1] transition toggle;
-		action do_nothing[e1, s2] transition toggle;
+		action do_nothing[e1, s1];
+		action do_nothing[e1, s2];
 	}

--- a/test/full_test132/test_fsm.fsm
+++ b/test/full_test132/test_fsm.fsm
@@ -24,8 +24,8 @@ machine test_fsm
 
 	include sub2.fsms
 
-	action handle_e1[e1, s1] transition s2;
-	action handle_e1[e1, s2] transition s1;
+	action handle_e1[e1, s1];
+	action handle_e1[e1, s2];
 
 }
 


### PR DESCRIPTION
The work for issue #195 allowed (for switch machine generation only) that action-transition matrices could be specified in machines having state-returning actions.  That was a mistake.  This PR reverses that and adds a parser check preventing the declarations.