### PR TITLE
Do not change namespace until machine name is readin order to keep th…

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -41,6 +41,7 @@
 int lineno=1;
 extern int yylineno;
 extern char *curfilename;
+pLIST root_id_list = NULL;
 pLIST id_list = NULL;
 
 //did we parse correctly?
@@ -386,7 +387,7 @@ machine:	machine_prefix machine_qualifier
            }
            else
            {
-            id_list = NULL;
+            id_list = root_id_list;
            }
 
 						#ifdef PARSER_DEBUG
@@ -3548,7 +3549,7 @@ int main(int argc, char **argv)
 		#endif
 
 			/* we need a base id_list for the machine names. */
-			if (NULL == (id_list = init_list()))
+			if (NULL == (root_id_list = id_list = init_list()))
 				yyerror("out of memory");
 			yyparse();
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -226,7 +226,7 @@ fsmlang: machine
 					}
 	;
 
-machine_prefix: native machine_modifier MACHINE_KEY 
+machine_prefix: native machine_modifier MACHINE_KEY ID
    {
 
 				if (($$ = (pMACHINE_PREFIX)calloc(1,sizeof(MACHINE_PREFIX))) == NULL)
@@ -245,6 +245,13 @@ machine_prefix: native machine_modifier MACHINE_KEY
        /* grab any modifiers */
  			 $$->pmachineInfo->modFlags = $2;
 
+			 /* grab our name */
+			 set_id_type($4, MACHINE);
+       $4->powningMachine = $$->pmachineInfo;
+			 $$->pmachineInfo->name = $4;
+
+
+				/* now give ourselves our own id list */
        id_list = $$->pmachineInfo->id_list = init_list();
 
         $$->pmachineInfo->parent = pmachineInfo;
@@ -253,9 +260,9 @@ machine_prefix: native machine_modifier MACHINE_KEY
    }
  	;
 
-machine:	machine_prefix ID machine_qualifier 
+machine:	machine_prefix machine_qualifier 
          {
-            if (!($3->modFlags & ACTIONS_RETURN_FLAGS))
+            if (!($2->modFlags & ACTIONS_RETURN_FLAGS))
             {
    						pID_INFO pid_event;
 							/* note that this is not added to the machine event list;
@@ -273,29 +280,28 @@ machine:	machine_prefix ID machine_qualifier
 						pid_state->powningMachine = pmachineInfo;
 						pid_state->order          = NO_TRANSITION;  // This makes it easier to detect.
 
-					pmachineInfo->modFlags |= $3->modFlags;
+					pmachineInfo->modFlags |= $2->modFlags;
          } 
         '{' statement_decl_list '}'
 					{
 
 						$$                     = $1->pmachineInfo;
 
-				    $$->name               = $2;
- 			      $$->modFlags          |= $3->modFlags;
- 			      $$->machineTransition  = $3->machineTransition;
-            $$->native_impl_prologue = $3->native_impl_prologue;
-            $$->native_impl_epilogue = $3->native_impl_epilogue;
+ 			      $$->modFlags          |= $2->modFlags;
+ 			      $$->machineTransition  = $2->machineTransition;
+            $$->native_impl_prologue = $2->native_impl_prologue;
+            $$->native_impl_epilogue = $2->native_impl_epilogue;
 
 						/* harvest the lists */
- 					$$->data               = $6->data;
- 					$$->state_list         = $6->pstate_and_event_decls->state_decls;
- 					$$->event_list         = $6->pstate_and_event_decls->event_decls;
- 					$$->action_list        = $6->pactions_and_transitions->action_list;
- 					$$->action_info_list   = $6->pactions_and_transitions->action_info_list;
- 					$$->transition_list    = $6->pactions_and_transitions->transition_list;
- 					$$->transition_fn_list = $6->pactions_and_transitions->transition_fn_list;
- 					$$->machine_list       = $6->pactions_and_transitions->machine_list;
-					$$->sequences          = $6->sequences;
+ 					$$->data               = $5->data;
+ 					$$->state_list         = $5->pstate_and_event_decls->state_decls;
+ 					$$->event_list         = $5->pstate_and_event_decls->event_decls;
+ 					$$->action_list        = $5->pactions_and_transitions->action_list;
+ 					$$->action_info_list   = $5->pactions_and_transitions->action_info_list;
+ 					$$->transition_list    = $5->pactions_and_transitions->transition_list;
+ 					$$->transition_fn_list = $5->pactions_and_transitions->transition_fn_list;
+ 					$$->machine_list       = $5->pactions_and_transitions->machine_list;
+					$$->sequences          = $5->sequences;
 
 						count_external_declarations     ($$->event_list,&($$->external_event_designation_count));
 						count_parent_event_referenced   ($$->event_list,&($$->parent_event_reference_count));
@@ -371,21 +377,12 @@ machine:	machine_prefix ID machine_qualifier
 
            free($1);
 
-           $2->powningMachine = pmachineInfo;
-
            /* reset context */
            pmachineInfo = $$->parent;
            if ($$->parent)
            {
-            pID_INFO pid;
-
             id_list = $$->parent->id_list;
-
-            add_id(id_list,MACHINE,$2->name,&pid);
-            pid->powningMachine = $$;
-
 						pmachineInfo = $$->parent;
-
            }
 
 						#ifdef PARSER_DEBUG
@@ -3546,6 +3543,8 @@ int main(int argc, char **argv)
 
 		#endif
 
+			//we need a base id_list for the machine names.
+			id_list = init_list();
 			yyparse();
 
 		#ifndef PARSER_DEBUG

--- a/src/parser.y
+++ b/src/parser.y
@@ -3543,8 +3543,9 @@ int main(int argc, char **argv)
 
 		#endif
 
-			//we need a base id_list for the machine names.
-			id_list = init_list();
+			/* we need a base id_list for the machine names. */
+			if (NULL == (id_list = init_list()))
+				yyerror("out of memory");
 			yyparse();
 
 		#ifndef PARSER_DEBUG

--- a/src/parser.y
+++ b/src/parser.y
@@ -384,6 +384,10 @@ machine:	machine_prefix machine_qualifier
             id_list = $$->parent->id_list;
 						pmachineInfo = $$->parent;
            }
+           else
+           {
+            id_list = NULL;
+           }
 
 						#ifdef PARSER_DEBUG
 

--- a/test/parser/parser-test45.canonical
+++ b/test/parser/parser-test45.canonical
@@ -157,7 +157,7 @@ process_action_info: noAction
 	iterate_matrix_states: event: e4
 		add_to_action_array: state: s4
 populate_action_array returning false
-found a machine named sub1
+found a machine named sub2
 	with 2 events and 2 states
 Actions return events
 Translators return void

--- a/test/parser/parser-test45.fsm
+++ b/test/parser/parser-test45.fsm
@@ -21,7 +21,7 @@ machine test
          	transition[e4,     s4] s3;
 	}
 
-	machine sub1
+	machine sub2
 	{
 		state s3, s4;
 		event e3, e4;

--- a/test/parser/parser-test49.canonical
+++ b/test/parser/parser-test49.canonical
@@ -1,0 +1,104 @@
+The 1 events in this list:
+	0:	e1
+
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1
+
+	1:	s2
+
+Found a namespace event reference
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1
+
+	1:	s2
+
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a1
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found an action without transition
+started an action declaration
+The actions in this list:
+	a2
+found a scalar event : e2
+found the beginning of a state comma list
+found a state vector
+	s1
+	s2
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a3
+process_action_info: a1
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s1
+process_action_info: a2
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s2
+process_action_info: a3
+	iterate_matrix_states: event: e2
+		add_to_action_array: state: s1
+		add_to_action_array: state: s2
+populate_action_array returning false
+found a machine named bar
+	with 2 events and 2 states
+Actions return events
+Translators return void
+The states :
+	0:	s1
+
+	1:	s2
+
+The events :
+	0:	e1
+
+	1:	e2
+
+The actions :
+	a1
+		which occurs for these events
+				e1
+		in these states
+				s1
+		and transitions to state s2
+	a2
+		which occurs for these events
+				e1
+		in these states
+				s2
+	a3
+		which occurs for these events
+				e2
+		in these states
+				s1
+				s2
+		and transitions to state s1
+
+The 2 transitions :
+	s2
+	s1
+
+test: parser-test49.fsm: syntax error
+	line 16 : bar

--- a/test/parser/parser-test49.fsm
+++ b/test/parser/parser-test49.fsm
@@ -1,0 +1,29 @@
+machine foo
+{
+	event e1;
+	state s1, s2;
+
+	machine bar
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	machine bar
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	transition [e1, s1] s2;
+	action a1[e1, s2];
+}
+


### PR DESCRIPTION
…e name in the parent's namespace.

closes #325 

The namespace id list was being changed before the reading of the machine name, placing that name into the new machine's namespace, rather than having it be added to the parent's.

We fix that and add a test to verify it.  We also fix a previous test which inadvertently verified it.