### PR TITLE
330 experimental allow data translators to be implemented by machines

### DIFF
--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -85,10 +85,10 @@ static bool print_event_macro(pLIST_ELEMENT, void *);
 static bool declare_shared_event_lists(pLIST_ELEMENT, void *);
 static bool declare_shared_event_data_blocks(pLIST_ELEMENT, void *);
 static void declare_parent_event_reference_data_structures(pCMachineData, pMACHINE_INFO);
-static void declare_state_implementing_machine_run_functions(pCMachineData);
-static bool declare_state_implementing_machine_run_function(pLIST_ELEMENT,void*);
-static bool define_state_implementing_machine_run_function(pLIST_ELEMENT,void*);
-static void print_state_implementing_machine_run_function_signature(pCMachineData,pMACHINE_INFO,FILE*,DECLARE_OR_DEFINE);
+static void declare_artifact_implementing_machine_run_functions(pCMachineData);
+static bool declare_artifact_implementing_machine_run_function(pLIST_ELEMENT,void*);
+static bool define_artifact_implementing_machine_run_function(pLIST_ELEMENT,void*);
+static void print_artifact_implementing_machine_run_function_signature(pCMachineData,pMACHINE_INFO,FILE*,DECLARE_OR_DEFINE);
 static void define_parent_event_reference_elements(pCMachineData, pMACHINE_INFO);
 static bool define_shared_event_lists(pLIST_ELEMENT, void *);
 static bool reference_shared_event_data_blocks(pLIST_ELEMENT, void *);
@@ -952,7 +952,7 @@ void commonHeaderStart(pFSMCOutputGenerator pfsmcog
 			   );
 
 		printSubMachinesDeclarations(pcmd, pmi);
-		declare_state_implementing_machine_run_functions(pcmd);
+		declare_artifact_implementing_machine_run_functions(pcmd);
 	}
 
 	/* put the data structure definition into the header */
@@ -2452,7 +2452,9 @@ static bool define_shared_event_lists(pLIST_ELEMENT pelem, void *data)
 	FSMLANG_DEVELOP_PRINTF(pich->ih.fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
 	if (ped->psharing_sub_machines
-		&& (ped->psharing_sub_machines->count != ped->state_implementing_sharer_count)
+		&& (ped->psharing_sub_machines->count != 
+			(ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count)
+			)
 	   )
 	{
 		pich->ih.pid   = pevent;
@@ -2862,6 +2864,30 @@ bool define_state_entry_and_exit_functions(pLIST_ELEMENT pelem, void *data)
 static void print_data_translator_fn_signature(FILE *fout, pCMachineData pcmd, pID_INFO pevent, DECLARE_OR_DEFINE dod)
 {
 	char *event_name_cp            = hungarianToUnderbarCaps(pevent->name);
+	pID_INFO ptranslator = pevent->type_data.event_data.puser_event_data
+							? pevent->type_data.event_data.puser_event_data->translator
+							: NULL
+							;
+
+	/* Set up the parameter strings. */
+	char *param_type, *param_name, *doxygen_block, *event_param, *event_name;
+	if ((pcmd->pmi->translators_implemented_by_machine != 0)
+		&& (ptranslator && (ptranslator->type_data.translator_data.flags & tf_implemented_by_sub_machine))
+		)
+	{
+		param_type = fsmType(pcmd);
+		param_name = ((dod == dod_define) || add_doxygen_blocks) ? " pfsm" : empty_str;
+		doxygen_block = add_doxygen_blocks ? " /**< Pointer to the FSM */" : empty_str;
+		event_param = eventType(pcmd);
+		event_name = " event";
+	}
+	else
+	{
+		param_type = fsmDataType(pcmd);
+		param_name = " pfsm_data";
+		doxygen_block = add_doxygen_blocks ? " /**< Pointer to the FSM's data */" : empty_str;
+		event_param = event_name = empty_str;
+	}
 
 	FSMLANG_DEVELOP_PRINTF(fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
@@ -2889,14 +2915,17 @@ static void print_data_translator_fn_signature(FILE *fout, pCMachineData pcmd, p
 				   );
 		}
 		fprintf(fout
-				, "(p%s%s%s,p%s_%s_DATA%s%s)%s\n"
-				, fsmDataType(pcmd)
-				, ((dod == dod_define) || add_doxygen_blocks) ? " pfsm_data" : ""
-				, add_doxygen_blocks ? " /**< Pointer to the FSM's data*/" : ""
+				, "(p%s%s%s, p%s_%s_DATA%s%s%s%s%s)%s\n"
+				, param_type
+				, param_name
+				, doxygen_block
 				, fsmType(pcmd)
 				, event_name_cp
 				, ((dod == dod_define) || add_doxygen_blocks) ? " pdata" : ""
 				, add_doxygen_blocks ? " /**< Pointer to the event's data*/" : ""
+				, event_param == empty_str ? empty_str : ", "
+				, event_param
+				, ((dod == dod_define) || add_doxygen_blocks) ? event_name : empty_str
 				, dod == dod_define ? "\n{" : ";"
 			   );
 	}
@@ -3680,7 +3709,8 @@ bool define_weak_action_function(pLIST_ELEMENT pelem, void *data)
 
 		/* and, that event will have a list of sharing machines */
 		if (ped->psharing_sub_machines
-			&& (ped->psharing_sub_machines->count != ped->state_implementing_sharer_count)
+			&& (ped->psharing_sub_machines->count 
+				!= (ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count))
 		   )
 		{
 			fprintf(pich->ih.fout
@@ -3736,7 +3766,8 @@ bool define_event_passing_actions(pLIST_ELEMENT pelem, void *data)
 
 		/* and, that event will have a list of sharing machines */
 		if (ped->psharing_sub_machines
-			&& (ped->psharing_sub_machines->count != ped->state_implementing_sharer_count)
+			&& (ped->psharing_sub_machines->count
+				!= (ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count))
 		   )
 		{
 			fprintf(pich->pcmd->cFile
@@ -4008,7 +4039,8 @@ static bool declare_shared_event_lists(pLIST_ELEMENT pelem, void *data)
 	FSMLANG_DEVELOP_PRINTF(pich->ih.fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
 	if (ped->psharing_sub_machines
-		&& (ped->psharing_sub_machines->count != ped->state_implementing_sharer_count)
+		&& (ped->psharing_sub_machines->count
+			!= (ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count))
 	   )
 	{
 
@@ -4107,17 +4139,30 @@ void declareEventDataManager(pCMachineData pcmd)
 
 static void print_event_data_manager_signature(pCMachineData pcmd, DECLARE_OR_DEFINE dod)
 {
+	/* Set up the parameter strings. */
+	char *param_type, *param_name;
+	if (pcmd->pmi->translators_implemented_by_machine != 0)
+	{
+		param_type = fsmType(pcmd);
+		param_name = (dod == dod_define) ? " pfsm" : empty_str;
+	}
+	else
+	{
+		param_type = fsmDataType(pcmd);
+		param_name = (dod == dod_define) ? " pfsm_data" : empty_str;
+	}
+
 	fprintf(pcmd->cFile
 			, "%sstatic %s translateEventData(p%s%s,%s%s)%s"
 			, dod == dod_define ? "\n" : ""
 			, translatorReturnType(pcmd)
-			, fsmDataType(pcmd)
-			, dod == dod_declare ? "" : " pfsm_data"
+			, param_type
+			, param_name
 			, fsmFnEventType(pcmd)
-			, dod == dod_declare ? "" : " pevent"
-			, dod == dod_declare
-			? ";\n\n"
-			: "\n{\n"
+			, dod == dod_define ? " pevent" : empty_str
+			, dod == dod_define
+			  ? "\n{\n"
+			  : ";\n\n"
 		   );
 }
 
@@ -4163,6 +4208,7 @@ static bool write_event_data_manager_switch_case(pLIST_ELEMENT pelem, void *data
 {
 	pID_INFO pevent                = (pID_INFO)pelem->mbr;
 	pITERATOR_CALLBACK_HELPER pich = (pITERATOR_CALLBACK_HELPER)data;
+	pEVENT_DATA ped                = &pevent->type_data.event_data;
 
 	FSMLANG_DEVELOP_PRINTF(pich->pcmd->cFile, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
@@ -4175,17 +4221,41 @@ static bool write_event_data_manager_switch_case(pLIST_ELEMENT pelem, void *data
 				, pevent->name
 			   );
 
+		char *param_name, *event_param;
+		if (pich->ih.pmi->translators_implemented_by_machine)
+		{
+			if (ped->puser_event_data->translator
+						  && (ped->puser_event_data->translator->type_data.translator_data.flags & tf_implemented_by_sub_machine)
+						  )
+			{
+				 param_name = "pfsm";
+				 event_param = ", pevent->event";
+			}
+			else
+			{
+				param_name = "&pfsm->data";
+				event_param = empty_str;
+			}
+		}
+		else
+		{
+			param_name = "pfsm_data";
+			event_param = empty_str;
+		}
+
 		fprintf(pich->pcmd->cFile
-				, pevent->type_data.event_data.puser_event_data->translator
-				? "\t\t%sUFMN(%s)(pfsm_data, &pevent->event_data.%s_data);\n\t\tbreak;\n"
-				: "\t\t%sUFMN(translate_%s_data)(pfsm_data, &pevent->event_data.%s_data);\n\t\tbreak;\n"
+				, ped->puser_event_data->translator
+				? "\t\t%sUFMN(%s)(%s, &pevent->event_data.%s_data%s);\n\t\tbreak;\n"
+				: "\t\t%sUFMN(translate_%s_data)(%s, &pevent->event_data.%s_data%s);\n\t\tbreak;\n"
 				, pich->ih.pmi->modFlags & mfTranslatorsReturnEvents
 				? "retVal = "
 				: ""
-				, pevent->type_data.event_data.puser_event_data->translator
-				? pevent->type_data.event_data.puser_event_data->translator->name
+				, ped->puser_event_data->translator
+				? ped->puser_event_data->translator->name
 				: pevent->name
+				, param_name
 				, pevent->name
+				, event_param
 			   );
 
 	}
@@ -4647,7 +4717,7 @@ void printFSMSubMachineDebugBlock(pCMachineData pcmd, pMACHINE_INFO pmi, bool al
 			, ucMachineName(pcmd)
 		   );
 
-	if (pmi->modFlags & mfStateImplementing)
+	if (pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 	{
 		fprintf(pcmd->cFile
 				, "extern char * %s_EVENT_NAMES[];\n"
@@ -5006,11 +5076,12 @@ static bool print_doxygen_return_statement(pLIST_ELEMENT pelem, void *data)
 	return false;
 }
 
-static void print_state_implementing_machine_run_function_signature(pCMachineData pcmd_parent, pMACHINE_INFO pmi_this, FILE *fout, DECLARE_OR_DEFINE dod)
+static void print_artifact_implementing_machine_run_function_signature(pCMachineData pcmd_parent, pMACHINE_INFO pmi_this, FILE *fout, DECLARE_OR_DEFINE dod)
 {
 	char *cp = NULL;
 	fprintf(fout
-			, "void run_%s(p%s%s,%s%s)%s"
+			, "%s run_%s(p%s%s,%s%s)%s"
+			, subFsmFnReturnType(pcmd_parent)
 			, fqMachineNamePmi(pmi_this,&cp)
 			, fsmType(pcmd_parent)
 			, dod == dod_define ? " pfsm" : ""
@@ -5021,27 +5092,27 @@ static void print_state_implementing_machine_run_function_signature(pCMachineDat
 	CHECK_AND_FREE(cp);
 }
 
-static bool declare_state_implementing_machine_run_function(pLIST_ELEMENT pelem, void *data)
+static bool declare_artifact_implementing_machine_run_function(pLIST_ELEMENT pelem, void *data)
 {
 	pITERATOR_CALLBACK_HELPER pich = (pITERATOR_CALLBACK_HELPER) data;
 	pMACHINE_INFO             pmi  = (pMACHINE_INFO) pelem->mbr;
 
-	if (pmi->modFlags & mfStateImplementing)
+	if (pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 	{
-		print_state_implementing_machine_run_function_signature(pich->pcmd, pmi, pich->ih.fout, dod_declare);
+		print_artifact_implementing_machine_run_function_signature(pich->pcmd, pmi, pich->ih.fout, dod_declare);
 	}
 
 	return false;
 }
 
-static bool define_state_implementing_machine_run_function(pLIST_ELEMENT pelem, void *data)
+static bool define_artifact_implementing_machine_run_function(pLIST_ELEMENT pelem, void *data)
 {
 	pITERATOR_CALLBACK_HELPER pich = (pITERATOR_CALLBACK_HELPER) data;
 	pMACHINE_INFO             pmi  = (pMACHINE_INFO) pelem->mbr;
 
-	if (pmi->modFlags & mfStateImplementing)
+	if (pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 	{
-		print_state_implementing_machine_run_function_signature(pich->pcmd, pmi, pich->ih.fout, dod_define);
+		print_artifact_implementing_machine_run_function_signature(pich->pcmd, pmi, pich->ih.fout, dod_define);
 
 		char *name = NULL;
 
@@ -5065,7 +5136,8 @@ static bool define_state_implementing_machine_run_function(pLIST_ELEMENT pelem, 
 					);
 		}
 		fprintf(pich->pcmd->cFile
-				, "\n\t(*%s_sub_fsm_if.subFSM)(pinstance,%sevent);\n"
+				, "\n\t%s(*%s_sub_fsm_if.subFSM)(pinstance,%sevent);\n"
+				, pich->ih.pmi->modFlags & ACTIONS_RETURN_FLAGS ? "" : "return "
 				, name
 				, pich->ih.pmi->data ? "&pfsm->data," : ""
 				);
@@ -5079,7 +5151,7 @@ static bool define_state_implementing_machine_run_function(pLIST_ELEMENT pelem, 
 	return false;
 }
 
-static void declare_state_implementing_machine_run_functions(pCMachineData pcmd)
+static void declare_artifact_implementing_machine_run_functions(pCMachineData pcmd)
 {
 	ITERATOR_CALLBACK_HELPER ich = {0};
 	ich.ih.fout = generate_instance ? pcmd->subMachineHFile : pcmd->pubHFile;
@@ -5088,13 +5160,13 @@ static void declare_state_implementing_machine_run_functions(pCMachineData pcmd)
 	FSMLANG_DEVELOP_PRINTF(ich.ih.fout, "/* FSMLANG DEVELOP: %s */\n", __func__);
 
 	iterate_list(pcmd->pmi->machine_list
-				 , declare_state_implementing_machine_run_function
+				 , declare_artifact_implementing_machine_run_function
 				 , &ich
 				 );
 
 }
 
-void define_state_implementing_machine_run_functions(pCMachineData pcmd)
+void define_artifact_implementing_machine_run_functions(pCMachineData pcmd)
 {
 	ITERATOR_CALLBACK_HELPER ich = {0};
 	ich.ih.fout = pcmd->cFile;
@@ -5104,7 +5176,7 @@ void define_state_implementing_machine_run_functions(pCMachineData pcmd)
 	FSMLANG_DEVELOP_PRINTF(ich.ih.fout, "/* FSMLANG DEVELOP: %s */\n", __func__);
 
 	iterate_list(pcmd->pmi->machine_list
-				 , define_state_implementing_machine_run_function
+				 , define_artifact_implementing_machine_run_function
 				 , &ich
 				 );
 

--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -2452,9 +2452,7 @@ static bool define_shared_event_lists(pLIST_ELEMENT pelem, void *data)
 	FSMLANG_DEVELOP_PRINTF(pich->ih.fout, "/* FSMLANG_DEVELOP: %s */\n", __func__);
 
 	if (ped->psharing_sub_machines
-		&& (ped->psharing_sub_machines->count != 
-			(ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count)
-			)
+		&& (ped->psharing_sub_machines->count != ped->state_implementing_sharer_count)
 	   )
 	{
 		pich->ih.pid   = pevent;
@@ -3766,8 +3764,7 @@ bool define_event_passing_actions(pLIST_ELEMENT pelem, void *data)
 
 		/* and, that event will have a list of sharing machines */
 		if (ped->psharing_sub_machines
-			&& (ped->psharing_sub_machines->count
-				!= (ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count))
+			&& (ped->psharing_sub_machines->count != ped->state_implementing_sharer_count)
 		   )
 		{
 			fprintf(pich->pcmd->cFile
@@ -4016,16 +4013,19 @@ static bool declare_shared_event_data_blocks(pLIST_ELEMENT pelem, void *data)
 	pMACHINE_INFO pmi    = (pMACHINE_INFO)pelem->mbr;
 	pITERATOR_CALLBACK_HELPER pich = (pITERATOR_CALLBACK_HELPER)data;
 
-	fprintf(pich->ih.fout, "extern ");
+	if (!(pmi->modFlags & mfStateImplementing))
+	{
+		fprintf(pich->ih.fout, "extern ");
 
-	print_shared_event_data_block_signature(pich->ih.fout
-											, pich->pcmd
-											, pmi
-											, pich->ih.pid->name
-											, true /* include type information */
-										   );
+		print_shared_event_data_block_signature(pich->ih.fout
+												, pich->pcmd
+												, pmi
+												, pich->ih.pid->name
+												, true /* include type information */
+											   );
 
-	fprintf(pich->ih.fout, ";\n");
+		fprintf(pich->ih.fout, ";\n");
+	}
 
 	return false;
 }
@@ -4040,7 +4040,7 @@ static bool declare_shared_event_lists(pLIST_ELEMENT pelem, void *data)
 
 	if (ped->psharing_sub_machines
 		&& (ped->psharing_sub_machines->count
-			!= (ped->state_implementing_sharer_count + ped->translator_implementing_sharer_count))
+			!= ped->state_implementing_sharer_count)
 	   )
 	{
 
@@ -4277,6 +4277,14 @@ static bool write_sub_machine_event_data_manager_switch_case(pLIST_ELEMENT pelem
 				, "\tcase THIS(%s):\n"
 				, pevent->name
 			   );
+		
+		if (pich->ih.pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
+		{
+			fprintf(pich->pcmd->cFile
+					, "\tcase PARENT(%s):\n"
+					, pevent->name
+				   );
+		}
 
 		fprintf(pich->pcmd->cFile
 				, pevent->type_data.event_data.puser_event_data->translator

--- a/src/fsm_c_common.h
+++ b/src/fsm_c_common.h
@@ -227,7 +227,7 @@ void declareEventDataManager(pCMachineData);
 void declareSubMachineEventDataManager(pCMachineData);
 void defineEventDataManager(pCMachineData);
 void defineSubMachineEventDataManager(pCMachineData);
-void define_state_implementing_machine_run_functions(pCMachineData);
+void define_artifact_implementing_machine_run_functions(pCMachineData);
 void printSubMachinesDeclarations(pCMachineData,pMACHINE_INFO);
 void printFSMMachineDebugBlock(pCMachineData,pMACHINE_INFO,bool);
 void printFSMSubMachineDebugBlock(pCMachineData,pMACHINE_INFO,bool);

--- a/src/fsm_c_switch_common.c
+++ b/src/fsm_c_switch_common.c
@@ -418,7 +418,7 @@ void writeOriginalSwitchSubFSMLoopAre(pFSMCOutputGenerator pfsmcog)
 	pCMachineData pcmd = pfsmcog->pcmd;
 	pMACHINE_INFO pmi  = pcmd->pmi;
 
-	if (pmi->modFlags & mfStateImplementing)
+	if (pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 	{
 		fprintf(pcmd->cFile
 			   , "\tdo\n\t{\n\n"
@@ -468,7 +468,7 @@ void writeOriginalSwitchSubFSMLoopAre(pFSMCOutputGenerator pfsmcog)
                );
    }
 
-   if (pmi->modFlags & mfStateImplementing)
+   if (pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
    {
 	   fprintf(pcmd->cFile
 			  , "\n\t} while (((e != THIS(noEvent)) && (e >= THIS(firstEvent)))"

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -612,7 +612,7 @@ static int writeCSwitchMachineInternal(pFSMCOutputGenerator pfsmcog)
       defineEventPassingActions(pcmd, pmi);
    }
 
-   define_state_implementing_machine_run_functions(pcmd);
+   define_artifact_implementing_machine_run_functions(pcmd);
 
    writeDebugInfo(pcmd, pmi);
 
@@ -1526,7 +1526,7 @@ static bool print_event_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
 					, pevent->name
 					);
 
-			if ((pich->ih.pmi->modFlags & mfStateImplementing)
+			if ((pich->ih.pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 				&& pevent->type_data.event_data.shared_with_parent
 				)
 			{
@@ -1669,7 +1669,7 @@ static bool print_transitions_only_case(pLIST_ELEMENT pelem, void *data)
 					, pevent->name
 					);
 
-			if ((pich->ih.pmi->modFlags & mfStateImplementing)
+			if ((pich->ih.pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 				&& pevent->type_data.event_data.shared_with_parent
 				)
 			{
@@ -2043,7 +2043,7 @@ static void writeSwitchSubFSMLoopInnards(pFSMCOutputGenerator pfsmcog, char *tab
 		   , pmi->modFlags & ACTIONS_RETURN_FLAGS ? "event" : "e"
            );
 
-   if (pmi->modFlags & mfStateImplementing)
+   if (pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
    {
 	   fprintf(pcmd->cFile
 			   , "\t\t   || ((%s >= PARENT(firstEvent)) && (%s < PARENT(noEvent)))\n"
@@ -2807,12 +2807,15 @@ static void set_local_fsm_fn_event_var(pCMachineData pcmd)
 
 	if (pmi->data_block_count)
 	{
+		char *fmt_str = pmi->modFlags & mfTranslatorsReturnEvents
+						? "\t%s e = translateEventData(%s, event);\n\n"
+						: "\t%s e = event->event;\n\n\ttranslateEventData(%s, event);\n"
+						;
+
 		fprintf(pcmd->cFile
-				, "\t%s e = %s"
+				, fmt_str
 				, eventType(pcmd)
-				, pmi->modFlags & mfTranslatorsReturnEvents
-				  ? "translateEventData(&pfsm->data, event);\n\n"
-				  : "event->event;\n\n\ttranslateEventData(&pfsm->data, event);\n"
+				, pmi->translators_implemented_by_machine ? "pfsm" : "&pfsm->data"
 			   );
 	}
 	else

--- a/src/fsm_html.c
+++ b/src/fsm_html.c
@@ -765,7 +765,7 @@ static bool print_event_table_event_row(pLIST_ELEMENT pelem, void *data)
 				fprintf(pih->fout, "</ul>\n");
 			}
 
-			if (translator->type_data.translator_data.consuming)
+			if (translator->type_data.translator_data.flags & tf_consuming)
 			{
 				fprintf(pih->fout
 						, "<p>The translator completely consumes the "

--- a/src/fsm_priv.h
+++ b/src/fsm_priv.h
@@ -68,6 +68,7 @@ typedef enum {
    , mfTranslatorsReturnEvents   = 16
    , mfTranslatorsReturnDeclared = 32
    , mfStateImplementing         = 64
+   , mfTranslatorImplementing    = 128
 } MOD_FLAGS;
 
 typedef enum {
@@ -77,6 +78,18 @@ typedef enum {
    , sfHasExitFn                   = 4
    , sfImplementedBySubMachine     = 8
 } STATE_FLAGS;
+
+typedef enum {
+    mpidf_none
+    , mpidf_implements_state       = 1
+    , mpidf_implements_translator  = 2
+} MACHINE_PID_FLAGS;
+
+typedef enum {
+    tf_none
+    , tf_consuming                  = 1
+    , tf_implemented_by_sub_machine = 2
+} TRANSLATOR_FLAGS;
 
 typedef enum HORIZONTAL_PLACEMENT {
    hp_none_given
@@ -112,6 +125,7 @@ typedef enum ANCESTRY_INCLUSION
 } ANCESTRY_INCLUSION;
 
 #define ACTIONS_RETURN_FLAGS (mfActionsReturnStates | mfActionsReturnVoid)
+#define ARTIFACTS_IMPLEMENTING_FLAGS (mfStateImplementing | mfTranslatorImplementing)
 
 typedef struct _id_info_				 ID_INFO,                 *pID_INFO;
 typedef struct _action_se_info_	         ACTION_SE_INFO,          *pACTION_SE_INFO;
@@ -184,6 +198,7 @@ struct _event_data_
    pLIST            psharing_sub_machines;
    bool             shared_with_parent;
    unsigned         state_implementing_sharer_count;
+   unsigned         translator_implementing_sharer_count;
    unsigned         single_pai_state_count;
    pACTION_INFO     psingle_pai;
    bool             single_pai_for_all_states;
@@ -202,14 +217,17 @@ struct _action_data_
 
 struct _translator_data_
 {
-	pLIST  translator_returns_decl;
-   bool   consuming;
+   TRANSLATOR_FLAGS flags;
+	pLIST            translator_returns_decl;
+   bool             consuming;
+   pID_INFO         implementingMachine;
 };
 
 struct _machine_pid_data_
 {
-    pID_INFO      implementedState;
-    pMACHINE_INFO pmi;
+    MACHINE_PID_FLAGS mpid_flags;
+    pID_INFO          implementedArtifact;
+    pMACHINE_INFO     pmi;
 };
 
 /**
@@ -369,6 +387,7 @@ struct _machine_info_ {
   unsigned      external_state_designation_count;
   unsigned      parent_event_reference_count;
   unsigned      data_translator_count;
+  unsigned      translators_implemented_by_machine;
   unsigned      data_block_count;
   unsigned      submachine_inhibitor_count;
   unsigned      submachines_wanting_parent_data_count;
@@ -443,6 +462,7 @@ void count_states_with_one_event(pLIST,unsigned*);
 void count_states_with_no_way_in(pLIST,unsigned*);
 void count_states_with_no_way_out(pLIST,unsigned*);
 void count_states_implemented_by_machine(pLIST,unsigned*);
+void count_translators_implemented_by_machine(pLIST,unsigned*);
 void count_events_with_zero_handlers(pLIST,unsigned*);
 void count_events_with_one_handler(pLIST,unsigned*);
 void compute_event_and_state_density_pct(pMACHINE_INFO);

--- a/src/fsm_rst.c
+++ b/src/fsm_rst.c
@@ -1087,6 +1087,23 @@ static void print_machine_statistics(pFSMRSTOutputGenerator pfsmrstog)
 			);
 
 	fprintf(FOUT(pfsmrstog)
+			, "%s* - Number of events with data translators:\n%s  - %u\n"
+			, indent
+			, indent
+			, PMI(pfsmrstog)->data_translator_count
+			);
+
+	if (PMI(pfsmrstog)->data_translator_count)
+	{
+		fprintf(FOUT(pfsmrstog)
+				, "%s* - Number of data translators implemented by sub-machine:\n%s  - %u\n"
+				, indent
+				, indent
+				, PMI(pfsmrstog)->translators_implemented_by_machine
+				);
+	}
+
+	fprintf(FOUT(pfsmrstog)
 			, "%s* - Number of states:\n%s  - %u\n"
 			, indent
 			, indent

--- a/src/fsm_statistics.c
+++ b/src/fsm_statistics.c
@@ -227,6 +227,10 @@ static bool write_machine_statistics(pLIST_ELEMENT pelem, void *data)
 		    : pmi->data_block_count
 		  );
 
+   printf("number of data translators implemented by machine: %u\n"
+		  , pmi->translators_implemented_by_machine
+		  );
+
    printf("translators return: ");
    if (pmi->modFlags & mfTranslatorsReturnEvents)
    {

--- a/src/fsm_utils.c
+++ b/src/fsm_utils.c
@@ -964,6 +964,24 @@ static bool count_implemented_by_machine_states(pLIST_ELEMENT pelem, void *data)
 	return false;
 }
 
+static bool count_implemented_by_machine_translators(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO         pevent = (pID_INFO)   pelem->mbr;
+	unsigned        *count  = (unsigned *) data;
+
+    if (pevent->type_data.event_data.puser_event_data)
+    {
+        pID_INFO ptranslator = pevent->type_data.event_data.puser_event_data->translator;
+
+        if (ptranslator && ptranslator->type_data.translator_data.flags & tf_implemented_by_sub_machine)
+        {
+            (*count)++;
+        }
+    }
+
+	return false;
+}
+
 void count_states_with_no_way_out(pLIST plist, unsigned *data)
 {
 	iterate_list(plist, count_no_way_out_states, data);
@@ -972,6 +990,11 @@ void count_states_with_no_way_out(pLIST plist, unsigned *data)
 void count_states_implemented_by_machine(pLIST plist, unsigned *data)
 {
 	iterate_list(plist, count_implemented_by_machine_states, data);
+}
+
+void count_translators_implemented_by_machine(pLIST plist, unsigned *data)
+{
+	iterate_list(plist, count_implemented_by_machine_translators, data);
 }
 
 void count_external_declarations(pLIST plist, unsigned *counter)

--- a/src/parser.y
+++ b/src/parser.y
@@ -124,6 +124,8 @@ static char *fsm_strndup(const char *s, size_t n)
 %token <pid_info> MACHINE
 %token <pid_info> UNDEFINED_SI_MACHINE
 %token <pid_info> SI_MACHINE
+%token <pid_info> UNDEFINED_TI_MACHINE
+%token <pid_info> TI_MACHINE
 %token <pid_info> STATE
 %token <pid_info> EVENT
 %token <pid_info> ACTION
@@ -238,6 +240,10 @@ machine_prefix: native machine_modifier MACHINE_KEY ID
 	 {
 		 $$ = machine_declared_by_machine_pid($1, $2, $4);
 	 }
+	 | native machine_modifier MACHINE_KEY UNDEFINED_TI_MACHINE
+	 {
+		 $$ = machine_declared_by_machine_pid($1, $2, $4);
+	 }
  	;
 
 machine:	machine_prefix machine_qualifier 
@@ -333,6 +339,10 @@ machine:	machine_prefix machine_qualifier
 
 					 count_states_implemented_by_machine($$->state_list
 																			 , &($$->states_implemented_by_machine)
+																			 );
+
+					 count_translators_implemented_by_machine($$->event_list
+																			 , &($$->translators_implemented_by_machine)
 																			 );
 
 						if (populate_action_array($$, yyout))
@@ -1886,43 +1896,16 @@ parent_namespace: PARENT NAMESPACE
 
 data_translator_fn: DATA_KEY TRANSLATOR_KEY ID
     {
-		  if (pmachineInfo->parent)
-		  {
-			  if (!pmachineInfo->parent->data) 
-			  {
-				  yyerror("data translator declared for sub-machine having parent with no data");
-			  }
-
-			  pmachineInfo->parent->submachines_wanting_parent_data_count++;
-		  }
-
-      $$ = $3;
-		  set_id_type($3, TRANSLATOR_FN);
-      
-      #ifdef PARSER_DEBUG
-      fprintf(yyout,"found a data translator: %s\n", $3->name);
-      #endif
+			$$ = data_translator($3);
     }
 	| CONSUMING DATA_KEY TRANSLATOR_KEY ID
 	  {
-		  if (pmachineInfo->parent)
-		  {
-			  if (!pmachineInfo->parent->data) 
-			  {
-				  yyerror("data translator declared for sub-machine having parent with no data");
-			  }
-
-			  pmachineInfo->parent->submachines_wanting_parent_data_count++;
-		  }
-
-      $$ = $4;
-		  set_id_type($4, TRANSLATOR_FN);
-			$4->type_data.translator_data.consuming = true;
-      
-      #ifdef PARSER_DEBUG
-      fprintf(yyout,"found a data translator: %s\n", $4->name);
-      #endif
+			$$ = consuming_data_translator($4);
 	  }
+	| data_translator_fn IMPLEMENTED BY MACHINE_KEY ID
+	{
+		$$ = translator_implemented_by($1, $5);
+	}
 	;
 
 user_event_data: { $$ = NULL; }
@@ -1977,7 +1960,7 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
 					 if ($4 && $4->translator)
 					 {
 						 $2->type_data.event_data.consumed_by_translator
-							 = $4->translator->type_data.translator_data.consuming;
+							 = ($4->translator->type_data.translator_data.flags & tf_consuming);
 					 }
 
  					if (NULL == ($2->type_data.event_data.phandling_states = init_list()))
@@ -2014,7 +1997,7 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
  					if ($5 && $5->translator)
 					 {
 						 pid->type_data.event_data.consumed_by_translator
-							 = $5->translator->type_data.translator_data.consuming;
+							 = ($5->translator->type_data.translator_data.flags & tf_consuming);
 					 }
 
  					if (NULL == (pid->type_data.event_data.phandling_states = init_list()))
@@ -2041,6 +2024,11 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
 							$3->type_data.event_data.state_implementing_sharer_count++;
 						}
 
+						if (pmachineInfo->modFlags & mfTranslatorImplementing)
+						{
+							$3->type_data.event_data.translator_implementing_sharer_count++;
+						}
+
 					}
 	| event_decl_list ',' ID external_designation user_event_data
 					{
@@ -2058,7 +2046,7 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
 					 if ($5 && $5->translator)
 					 {
 						 $3->type_data.event_data.consumed_by_translator
-							 = $5->translator->type_data.translator_data.consuming;
+							 = ($5->translator->type_data.translator_data.flags & tf_consuming);
 					 }
 
  					if (NULL == ($3->type_data.event_data.phandling_states = init_list()))
@@ -2094,7 +2082,7 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
  					if ($6 && $6->translator)
 					 {
 						 pid->type_data.event_data.consumed_by_translator
-							 = $6->translator->type_data.translator_data.consuming;
+							 = ($6->translator->type_data.translator_data.flags & tf_consuming);
 					 }
 
  					if (NULL == (pid->type_data.event_data.phandling_states = init_list()))

--- a/src/parser_support.c
+++ b/src/parser_support.c
@@ -53,7 +53,23 @@ extern pLIST         id_list;
 extern pMACHINE_INFO pmachineInfo;
 
 static pMACHINE_PREFIX create_machine_prefix(pNATIVE_INFO,MOD_FLAGS,pID_INFO);
+static void data_translator_common(pID_INFO);
 
+/**
+ * Capture the info for the state and the machine implementing
+ * it.
+ *
+ * At this point, the machine is prospective, it will need to
+ * be found later.
+ * 
+ * @author Steven Stanton (8/21/2026)
+ * 
+ * @param pstate   The state being implemented by a machine.
+ * @param pmachine The name of the machine which will implement
+ *  			   the state.
+ * 
+ * @return pID_INFO The state, as needed by the parsing tree.
+ */
 pID_INFO state_implemented_by(pID_INFO pstate, pID_INFO pmachine)
 {
 #ifdef PARSER_DEBUG
@@ -73,9 +89,87 @@ pID_INFO state_implemented_by(pID_INFO pstate, pID_INFO pmachine)
 	pstate->type_data.state_data.implementingMachine  = pmachine;
 
 	set_id_type(pmachine, UNDEFINED_SI_MACHINE);
-	pmachine->type_data.machine_pid_data.implementedState = pstate;
+	pmachine->type_data.machine_pid_data.mpid_flags          = mpidf_implements_state;
+	pmachine->type_data.machine_pid_data.implementedArtifact = pstate;
 
 	return pstate;
+}
+
+static void data_translator_common(pID_INFO ptranslator)
+{
+	if (pmachineInfo->parent)
+	{
+		if (!pmachineInfo->parent->data) 
+		{
+			yyerror("data translator declared for sub-machine having parent with no data");
+		}
+
+		pmachineInfo->parent->submachines_wanting_parent_data_count++;
+	}
+
+	set_id_type(ptranslator, TRANSLATOR_FN);
+
+#ifdef PARSER_DEBUG
+fprintf(yyout,"found a data translator: %s\n", ptranslator->name);
+#endif
+}
+
+pID_INFO data_translator(pID_INFO ptranslator)
+{
+	data_translator_common(ptranslator);
+	return ptranslator;
+}
+
+pID_INFO consuming_data_translator(pID_INFO ptranslator)
+{
+	data_translator_common(ptranslator);
+	ptranslator->type_data.translator_data.flags |= tf_consuming;
+	return ptranslator;
+}
+
+/**
+ * Capture the info for the translator and the machine implementing
+ * it.
+ *
+ * At this point, the machine is prospective, it will need to
+ * be found later.
+ * 
+ * @author Steven Stanton (8/21/2026)
+ * 
+ * @param ptranslator   The translator being implemented by a machine.
+ * @param pmachine The name of the machine which will implement
+ *  			   the translator.
+ * 
+ * @return pID_INFO The translator, as needed by the parsing tree.
+ */
+pID_INFO translator_implemented_by(pID_INFO ptranslator, pID_INFO pmachine)
+{
+#ifdef PARSER_DEBUG
+	fprintf(yyout
+			, "translator %s implemented by submachine %s\n"
+			, ptranslator->name
+			, pmachine->name
+		   );
+#endif
+
+	if (
+		(pmachineInfo->modFlags & mfTranslatorsReturnEvents)
+		&& (pmachineInfo->modFlags & ACTIONS_RETURN_FLAGS)
+		)
+	{
+		yyerror("It does not make sense to implement data translators which return events"
+				"with sub-machines which do not."
+				);
+	}
+
+	ptranslator->type_data.translator_data.flags               |= tf_implemented_by_sub_machine;
+	ptranslator->type_data.translator_data.implementingMachine  = pmachine;
+
+	set_id_type(pmachine, UNDEFINED_TI_MACHINE);
+	pmachine->type_data.machine_pid_data.mpid_flags          = mpidf_implements_translator;
+	pmachine->type_data.machine_pid_data.implementedArtifact = ptranslator;
+
+	return ptranslator;
 }
 
 /**
@@ -143,17 +237,24 @@ pMACHINE_PREFIX machine_declared_by_id(pNATIVE_INFO pnative, MOD_FLAGS machine_m
 	return create_machine_prefix(pnative,machine_modifier,pid);
 }
 
-pMACHINE_PREFIX machine_declared_by_machine_pid(pNATIVE_INFO pnative, MOD_FLAGS machine_modifier, pID_INFO pid)
+pMACHINE_PREFIX machine_declared_by_machine_pid(pNATIVE_INFO pnative, MOD_FLAGS machine_modifier, pID_INFO machine_pid)
 {
 	pMACHINE_PREFIX pmachine_prefix = NULL;
 
-	set_id_type(pid, SI_MACHINE);
-
-	machine_modifier |= mfStateImplementing;
+	if (machine_pid->type_data.machine_pid_data.mpid_flags & mpidf_implements_state)
+	{
+		set_id_type(machine_pid, SI_MACHINE);
+		machine_modifier |= mfStateImplementing;
+	}
+	else
+	{
+		set_id_type(machine_pid, TI_MACHINE);
+		machine_modifier |= mfTranslatorImplementing;
+	}
 
 	pmachine_prefix = create_machine_prefix(pnative
 											, machine_modifier
-											, pid
+											, machine_pid
 											);
 
 	if (pmachine_prefix == NULL)
@@ -161,7 +262,7 @@ pMACHINE_PREFIX machine_declared_by_machine_pid(pNATIVE_INFO pnative, MOD_FLAGS 
 		yyerror("out of memory");
 	}
 
-	pid->type_data.machine_pid_data.pmi = pmachine_prefix->pmachineInfo;
+	machine_pid->type_data.machine_pid_data.pmi = pmachine_prefix->pmachineInfo;
 
 	return pmachine_prefix;
 }

--- a/src/parser_support.h
+++ b/src/parser_support.h
@@ -39,6 +39,9 @@
 #include "fsm_priv.h"
 
 pID_INFO state_implemented_by(pID_INFO,pID_INFO);
+pID_INFO data_translator(pID_INFO);
+pID_INFO consuming_data_translator(pID_INFO);
+pID_INFO translator_implemented_by(pID_INFO,pID_INFO);
 pMACHINE_PREFIX machine_declared_by_id(pNATIVE_INFO,MOD_FLAGS,pID_INFO);
 pMACHINE_PREFIX machine_declared_by_machine_pid(pNATIVE_INFO,MOD_FLAGS,pID_INFO);
 

--- a/test/full_test107/sub.rst.canonical
+++ b/test/full_test107/sub.rst.canonical
@@ -18,6 +18,8 @@ sub
      - 2
    * - At least one event handled the same in all states?
      - no
+   * - Number of events with data translators:
+     - 0
    * - Number of states:
      - 3
    * - Number of states with entry functions:

--- a/test/full_test107/test_fsm.rst.canonical
+++ b/test/full_test107/test_fsm.rst.canonical
@@ -25,6 +25,8 @@ test_fsm
      - 2
    * - At least one event handled the same in all states?
      - no
+   * - Number of events with data translators:
+     - 0
    * - Number of states:
      - 3
    * - Number of states with entry functions:

--- a/test/full_test108/sub.rst.canonical
+++ b/test/full_test108/sub.rst.canonical
@@ -18,6 +18,8 @@ sub
      - 2
    * - At least one event handled the same in all states?
      - no
+   * - Number of events with data translators:
+     - 0
    * - Number of states:
      - 3
    * - Number of states with entry functions:

--- a/test/full_test108/test_fsm.rst.canonical
+++ b/test/full_test108/test_fsm.rst.canonical
@@ -25,6 +25,8 @@ test_fsm
      - 2
    * - At least one event handled the same in all states?
      - no
+   * - Number of events with data translators:
+     - 0
    * - Number of states:
      - 3
    * - Number of states with entry functions:

--- a/test/full_test148/test_fsm_priv.h.canonical
+++ b/test/full_test148/test_fsm_priv.h.canonical
@@ -104,7 +104,7 @@ void test_fsm_exit_s1(pTEST_FSM_DATA pdata /**< Pointer to the FSM's data */);
 	Grab e1 data.
 
 */
-void test_fsm_grab_e1_data(pTEST_FSM_DATA pfsm_data /**< Pointer to the FSM's data*/,pTEST_FSM_E1_DATA pdata /**< Pointer to the event's data*/);
+void test_fsm_grab_e1_data(pTEST_FSM_DATA pfsm_data /**< Pointer to the FSM's data */, pTEST_FSM_E1_DATA pdata /**< Pointer to the event's data*/);
 
 
 

--- a/test/full_test154/Makefile
+++ b/test/full_test154/Makefile
@@ -18,13 +18,13 @@ override CFLAGS += -I../                  \
 override DIFF_FLAGS= -I \"warning: (test_fsm_sub_subSub): all events are handled identically in all states.\"  \
             -I \"warning: (test_fsm_sub2_subSub): all events are handled identically in all states.\"  
 
-FSM_FLAGS+=--add-profiling-macros=true --profile-sub-fsms=true
-
 VARIANTS=s
 #TARGET=pass
 
 #include ../weak_variants.mk
 include ../variants.mk
+
+FSM_FLAGS+=--add-profiling-macros=true --profile-sub-fsms=true
 
 FSM_FLAGS += -i3
 

--- a/test/full_test154/test.canonical
+++ b/test/full_test154/test.canonical
@@ -49,8 +49,6 @@ communicator_first_connection_noAction
 end state: communicator_first_connection_waiting
 end state: communicator_first_time_connect
 communicator_grab_ble_comm
-event: communicator_ble_comm; state: communicator_first_time_connect
-communicator_forward_ble_comm
 communicator_ble_translate_ble_comm
 event: communicator_ble_adv_packet; state: communicator_ble_scanning
 communicator_ble_parse_adv_packet

--- a/test/full_test154/test.canonical
+++ b/test/full_test154/test.canonical
@@ -13,9 +13,7 @@ end state: communicator_ble_waiting
 communicator_set_defaults
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: []
@@ -28,9 +26,7 @@ communicator_commands_check_pairing_info
 end state: communicator_commands_waiting_pairing_info
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: [012345678901]
@@ -98,9 +94,7 @@ end state: communicator_ble_waiting
 communicator_set_defaults
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: []
@@ -113,9 +107,7 @@ communicator_commands_check_pairing_info
 end state: communicator_commands_waiting_pairing_info
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: []
@@ -128,9 +120,7 @@ communicator_commands_check_pairing_info
 end state: communicator_commands_waiting_pairing_info
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: []
@@ -143,9 +133,7 @@ communicator_commands_check_pairing_info
 end state: communicator_commands_waiting_pairing_info
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: []
@@ -158,9 +146,7 @@ communicator_commands_check_pairing_info
 end state: communicator_commands_waiting_pairing_info
 end state: communicator_waiting
 communicator_grab_command
-event: communicator_command; state: communicator_waiting
-communicator_forward_command
-event: communicator_commands_command; state: communicator_commands_waiting_pairing_info
+event: communicator_command; state: communicator_commands_waiting_pairing_info
 communicator_commands_parse_command
 peer_id: [5678]
 peer_sn: []

--- a/test/full_test154/test_fsm-actions.c
+++ b/test/full_test154/test_fsm-actions.c
@@ -1,10 +1,11 @@
 #include "test_fsm_priv.h"
 
-TRANSLATOR_RETURN_TYPE UFMN(grab_command)(pCOMMUNICATOR_DATA pfsm_data, pCOMMUNICATOR_COMMAND_DATA pcommand_data)
+TRANSLATOR_RETURN_TYPE UFMN(grab_command)(pCOMMUNICATOR pfsm, pCOMMUNICATOR_COMMAND_DATA pcommand_data, COMMUNICATOR_EVENT_ENUM event)
 {
 	DBG_PRINTF("%s", __func__);
 	
-	pfsm_data->pcurr_command = &pcommand_data->command;
+	pfsm->data.pcurr_command = &pcommand_data->command;
+	return run_communicator_commands(pfsm, event);
 }
 
 TRANSLATOR_RETURN_TYPE UFMN(grab_ble_comm)(pCOMMUNICATOR_DATA pfsm_data, pCOMMUNICATOR_BLE_COMM_DATA pble_comm_data)
@@ -12,6 +13,8 @@ TRANSLATOR_RETURN_TYPE UFMN(grab_ble_comm)(pCOMMUNICATOR_DATA pfsm_data, pCOMMUN
 	DBG_PRINTF("%s", __func__);
 	
 	pfsm_data->pcurr_ble_event = &pble_comm_data->ble_e;
+
+	return THIS(ble_comm);
 }
 
 ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)

--- a/test/full_test154/test_fsm-actions.c
+++ b/test/full_test154/test_fsm-actions.c
@@ -8,11 +8,11 @@ TRANSLATOR_RETURN_TYPE UFMN(grab_command)(pCOMMUNICATOR pfsm, pCOMMUNICATOR_COMM
 	return run_communicator_commands(pfsm, event);
 }
 
-TRANSLATOR_RETURN_TYPE UFMN(grab_ble_comm)(pCOMMUNICATOR_DATA pfsm_data, pCOMMUNICATOR_BLE_COMM_DATA pble_comm_data, COMMUNICATOR_EVENT_ENUM event)
+TRANSLATOR_RETURN_TYPE UFMN(grab_ble_comm)(pCOMMUNICATOR pfsm, pCOMMUNICATOR_BLE_COMM_DATA pble_comm_data, COMMUNICATOR_EVENT_ENUM event)
 {
 	DBG_PRINTF("%s", __func__);
 	
-	pfsm_data->pcurr_ble_event = &pble_comm_data->ble_e;
+	pfsm->data.pcurr_ble_event = &pble_comm_data->ble_e;
 
 	return run_communicator_ble(pfsm, event);
 }

--- a/test/full_test154/test_fsm-actions.c
+++ b/test/full_test154/test_fsm-actions.c
@@ -8,13 +8,13 @@ TRANSLATOR_RETURN_TYPE UFMN(grab_command)(pCOMMUNICATOR pfsm, pCOMMUNICATOR_COMM
 	return run_communicator_commands(pfsm, event);
 }
 
-TRANSLATOR_RETURN_TYPE UFMN(grab_ble_comm)(pCOMMUNICATOR_DATA pfsm_data, pCOMMUNICATOR_BLE_COMM_DATA pble_comm_data)
+TRANSLATOR_RETURN_TYPE UFMN(grab_ble_comm)(pCOMMUNICATOR_DATA pfsm_data, pCOMMUNICATOR_BLE_COMM_DATA pble_comm_data, COMMUNICATOR_EVENT_ENUM event)
 {
 	DBG_PRINTF("%s", __func__);
 	
 	pfsm_data->pcurr_ble_event = &pble_comm_data->ble_e;
 
-	return THIS(ble_comm);
+	return run_communicator_ble(pfsm, event);
 }
 
 ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)

--- a/test/full_test154/test_fsm.fsm
+++ b/test/full_test154/test_fsm.fsm
@@ -41,7 +41,7 @@ data
 	event command data translator grab_command implemented by machine commands {command_str command;};
 	event configuration_complete;
 
-	event ble_comm data translator grab_ble_comm {ble_event_str ble_e;};
+	event ble_comm data translator grab_ble_comm implemented by machine ble {ble_event_str ble_e;};
 
 	event peer_connected;
 	event start_auth1;
@@ -66,18 +66,10 @@ data
 	include first_connection.fsms
 
 	action activate_all     [activate, (all)]                 transition waiting;
-	//action forward_command  [command, waiting];
 	action start_looking    [configuration_complete, waiting] transition first_time_connect;
 
-	/*
-	action forward_peer_connected [peer_connected, first_time_connect];
-	action forward_auth1_complete [auth1_complete, first_time_connect];
-	action forward_auth2_complete [auth2_complete, first_time_connect];
-	action forward_peer_data_synced [peer_data_synced, first_time_connect] transition connected_to_peer;
-	*/
 	transition [peer_data_synced, first_time_connect] connected_to_peer;
 
-	action forward_ble_comm [ble_comm, (all)];
 
 }
 

--- a/test/full_test154/test_fsm.fsm
+++ b/test/full_test154/test_fsm.fsm
@@ -13,6 +13,7 @@ native
 
 }
 machine communicator
+	data translators return events;
 
 native impl
 {
@@ -37,7 +38,7 @@ data
 
 	event activate;
 
-	event command data translator grab_command {command_str command;};
+	event command data translator grab_command implemented by machine commands {command_str command;};
 	event configuration_complete;
 
 	event ble_comm data translator grab_ble_comm {ble_event_str ble_e;};
@@ -65,7 +66,7 @@ data
 	include first_connection.fsms
 
 	action activate_all     [activate, (all)]                 transition waiting;
-	action forward_command  [command, waiting];
+	//action forward_command  [command, waiting];
 	action start_looking    [configuration_complete, waiting] transition first_time_connect;
 
 	/*

--- a/test/lexer/lexer-test31.canonical
+++ b/test/lexer/lexer-test31.canonical
@@ -1,0 +1,427 @@
+NATIVE_KEY
+PROLOGUE_KEY
+Native:
+
+Copy this to the header file.
+DEFINE INIT_FSM_DATA {{0,0}, 1}
+
+NATIVE_KEY
+EPILOGUE_KEY
+Native:
+
+Copy this to the header file at the end.
+
+MACHINE_KEY
+Added : newMachine of type ID
+newMachine : ID
+ON
+TRANSITION_KEY
+Added : baz of type ID
+baz : ID
+;
+DATA_KEY
+TRANSLATORS
+RETURN
+EVENTS
+;
+NATIVE_KEY
+IMPLEMENTATION_KEY
+PROLOGUE_KEY
+Native:
+ copy this to the source file; 
+NATIVE_KEY
+IMPLEMENTATION_KEY
+EPILOGUE_KEY
+Native:
+ copy this to the source file at the end; 
+{
+DATA_KEY
+{
+UNION_KEY
+{
+STRUCT_KEY
+{
+Added : int of type ID
+int : ID
+Added : a of type ID
+a : ID
+;
+}
+Added : str_int of type ID
+str_int : ID
+Added : foo of type ID
+foo : ID
+;
+STRUCT_KEY
+{
+Added : float of type ID
+float : ID
+Added : f of type ID
+f : ID
+;
+}
+Added : str_float of type ID
+str_float : ID
+Added : beep of type ID
+beep : ID
+;
+Found : int of type ID
+int : ID
+Added : bop of type ID
+bop : ID
+;
+}
+;
+}
+STATE_KEY
+Added : s1 of type ID
+s1 : ID
+,
+Added : s2 of type ID
+s2 : ID
+,
+Added : s3 of type ID
+s3 : ID
+IMPLEMENTED
+BY
+MACHINE_KEY
+Added : s3_sub of type ID
+s3_sub : ID
+,
+Added : s4 of type ID
+s4 : ID
+INHIBITS
+SUBMACHINES
+ON
+ENTRY
+;
+EVENT_KEY
+Added : e1 of type ID
+e1 : ID
+CONSUMING
+DATA_KEY
+TRANSLATOR_KEY
+Added : e1_dt of type ID
+e1_dt : ID
+IMPLEMENTED
+BY
+MACHINE_KEY
+Added : e1_dt_mach of type ID
+e1_dt_mach : ID
+{
+Found : int of type ID
+int : ID
+Found : a of type ID
+a : ID
+;
+}
+,
+Added : e2 of type ID
+e2 : ID
+,
+Added : e3 of type ID
+e3 : ID
+;
+EVENT_KEY
+Added : e4 of type ID
+e4 : ID
+=
+Added : BAR of type ID
+BAR : ID
+;
+Doc Comment:
+ a sub machine 
+MACHINE_KEY
+Added : subMachine1 of type ID
+subMachine1 : ID
+DATA_KEY
+TRANSLATORS
+RETURN
+VOID
+;
+{
+STATE_KEY
+Added : ss1 of type ID
+ss1 : ID
+ON
+ENTRY
+Found : foo of type ID
+foo : ID
+ON
+EXIT
+Added : bar of type ID
+bar : ID
+,
+Added : ss2 of type ID
+ss2 : ID
+ON
+ENTRY
+ON
+EXIT
+,
+Added : ss3 of type ID
+ss3 : ID
+ON
+ENTRY
+Added : foo1 of type ID
+foo1 : ID
+,
+Added : ss4 of type ID
+ss4 : ID
+ON
+EXIT
+Added : bar1 of type ID
+bar1 : ID
+;
+EVENT_KEY
+Added : ee1 of type ID
+ee1 : ID
+,
+Added : ee2 of type ID
+ee2 : ID
+,
+Added : ee3 of type ID
+ee3 : ID
+;
+Doc Comment:
+ a sub-sub machine 
+MACHINE_KEY
+Added : subSubMachine1 of type ID
+subSubMachine1 : ID
+{
+STATE_KEY
+Added : z1 of type ID
+z1 : ID
+,
+Added : z2 of type ID
+z2 : ID
+;
+EVENT_KEY
+Added : y1 of type ID
+y1 : ID
+,
+Added : y2 of type ID
+y2 : ID
+;
+ACTION_KEY
+Added : x1 of type ID
+x1 : ID
+[
+Found : y1 of type ID
+y1 : ID
+,
+Found : z1 of type ID
+z1 : ID
+]
+;
+ACTION_KEY
+Added : x2 of type ID
+x2 : ID
+[
+Found : y2 of type ID
+y2 : ID
+,
+(
+ALL
+)
+]
+TRANSITION_KEY
+Found : z1 of type ID
+z1 : ID
+;
+}
+ACTION_KEY
+Added : aa1 of type ID
+aa1 : ID
+[
+Found : ee1 of type ID
+ee1 : ID
+,
+Found : ss1 of type ID
+ss1 : ID
+]
+TRANSITION_KEY
+Found : ss2 of type ID
+ss2 : ID
+;
+ACTION_KEY
+Added : aa2 of type ID
+aa2 : ID
+[
+Found : ee2 of type ID
+ee2 : ID
+,
+Found : ss1 of type ID
+ss1 : ID
+]
+TRANSITION_KEY
+Found : ss3 of type ID
+ss3 : ID
+;
+}
+Doc Comment:
+ a second sub machine 
+MACHINE_KEY
+Added : subMachine2 of type ID
+subMachine2 : ID
+{
+STATE_KEY
+Added : sss1 of type ID
+sss1 : ID
+,
+Added : sss2 of type ID
+sss2 : ID
+,
+Added : sss3 of type ID
+sss3 : ID
+;
+EVENT_KEY
+Added : eee1 of type ID
+eee1 : ID
+,
+Added : eee2 of type ID
+eee2 : ID
+,
+Added : eee3 of type ID
+eee3 : ID
+;
+ACTION_KEY
+Added : aaa1 of type ID
+aaa1 : ID
+[
+Found : ee1 of type ID
+ee1 : ID
+,
+Found : sss1 of type ID
+sss1 : ID
+]
+TRANSITION_KEY
+Found : sss2 of type ID
+sss2 : ID
+;
+ACTION_KEY
+Added : aaa2 of type ID
+aaa2 : ID
+[
+Found : eee2 of type ID
+eee2 : ID
+,
+Found : sss1 of type ID
+sss1 : ID
+]
+TRANSITION_KEY
+Found : sss3 of type ID
+sss3 : ID
+;
+}
+ACTION_KEY
+Added : a1 of type ID
+a1 : ID
+[
+Found : e1 of type ID
+e1 : ID
+,
+Found : s1 of type ID
+s1 : ID
+]
+TRANSITION_KEY
+Found : s1 of type ID
+s1 : ID
+;
+Doc Comment:
+
+		A Document Comment
+	
+ACTION_KEY
+Added : a2 of type ID
+a2 : ID
+[
+Found : e1 of type ID
+e1 : ID
+,
+(
+Found : s2 of type ID
+s2 : ID
+,
+Found : s3 of type ID
+s3 : ID
+)
+]
+TRANSITION_KEY
+Found : s1 of type ID
+s1 : ID
+;
+TRANSITION_KEY
+[
+(
+Found : e2 of type ID
+e2 : ID
+,
+Found : e3 of type ID
+e3 : ID
+)
+,
+(
+Found : s1 of type ID
+s1 : ID
+,
+Found : s2 of type ID
+s2 : ID
+,
+Found : s3 of type ID
+s3 : ID
+)
+]
+Added : guardFn1 of type ID
+guardFn1 : ID
+;
+Found : guardFn1 of type ID
+guardFn1 : ID
+RETURNS
+Found : s2 of type ID
+s2 : ID
+WHEN_KEY
+Added : conditionFn1 of type ID
+conditionFn1 : ID
+,
+Found : s1 of type ID
+s1 : ID
+OTHERWISE_KEY
+;
+ACTION_KEY
+Added : doNothing of type ID
+doNothing : ID
+[
+(
+ALL
+)
+,
+Found : s4 of type ID
+s4 : ID
+]
+;
+Found : a2 of type ID
+a2 : ID
+RETURNS
+Added : noEvent of type ID
+noEvent : ID
+;
+SEQUENCE_KEY
+Added : one of type ID
+one : ID
+START_KEY
+Found : s2 of type ID
+s2 : ID
+Found : e1 of type ID
+e1 : ID
+,
+Found : e3 of type ID
+e3 : ID
+,
+Found : e4 of type ID
+e4 : ID
+END_KEY
+Found : s1 of type ID
+s1 : ID
+;
+}

--- a/test/lexer/lexer-test31.txt
+++ b/test/lexer/lexer-test31.txt
@@ -1,0 +1,100 @@
+/*
+	Here are some comments
+*/
+native prologue
+{
+Copy this to the header file.
+DEFINE INIT_FSM_DATA {{0,0}, 1}
+}
+
+native epilogue
+{
+Copy this to the header file at the end.
+}
+
+machine newMachine
+ on transition baz;
+ data translators return events;
+ native impl prologue { copy this to the source file; }
+ native impl epilogue { copy this to the source file at the end; }
+{
+data
+{
+
+ union
+ {
+  struct 
+  {
+  	int a;
+  } str_int foo;
+  
+  struct
+  {
+   float f;
+  } str_float beep;
+ 
+  int  bop;
+ };
+
+}
+
+	state s1, s2, s3 implemented by machine s3_sub, s4 inhibits submachines on entry;
+	event e1 consuming data translator e1_dt implemented by machine e1_dt_mach {int a;}
+         , e2
+         , e3
+         ;
+  event e4 = BAR;
+
+
+	/** a sub machine */
+  machine subMachine1
+    data translators return void;
+  {
+		state ss1 on entry foo on exit bar
+           , ss2 on entry on exit
+           , ss3 on entry foo1
+           , ss4 on exit bar1
+           ;
+		event ee1, ee2, ee3;
+
+		/** a sub-sub machine */
+		machine subSubMachine1
+      {
+			state z1, z2;
+			event y1, y2;
+
+			action x1[y1,z1];
+			action x2[y2, (all)] transition z1;
+		}
+
+		action aa1[ee1,ss1] transition ss2;
+		action aa2[ee2, ss1] transition ss3;
+	}
+
+	/** a second sub machine */
+  machine subMachine2 {
+		state sss1, sss2, sss3;
+		event eee1, eee2, eee3;
+
+		action aaa1[ee1,sss1] transition sss2;
+		action aaa2[eee2, sss1] transition sss3;
+	}
+
+	//This is a one-line comment
+	action a1[e1,s1] transition s1;
+
+	/**
+		A Document Comment
+	*/
+	action a2[e1,(s2,s3)] transition s1;
+	transition [(e2,e3),(s1,s2,s3)] guardFn1;
+	guardFn1 returns s2 when conditionFn1, s1 otherwise;
+
+	action doNothing[(all), s4];
+
+	a2 returns noEvent;
+
+	sequence one start s2 e1, e3, e4 end s1;
+
+}
+

--- a/test/parser/parser-test53.canonical
+++ b/test/parser/parser-test53.canonical
@@ -1,0 +1,256 @@
+found simple data type id
+found data field: TYPE: simple; NAME: i
+Starting data_fields list
+Data block done
+found a data translator: foo
+translator foo implemented by submachine baz
+found simple data type name
+found data field: TYPE: simple; NAME: i
+Starting data_fields list
+Data block done
+found data fields
+int i;
+
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+state s1 implemented by submachine bar
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1; This state is implemented by machine bar.
+
+	1:	s2
+
+Found a namespace event reference
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1
+
+	1:	s2
+
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a1
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found an action without transition
+started an action declaration
+The actions in this list:
+	a2
+found a scalar event : e2
+found the beginning of a state comma list
+found a state vector
+	s1
+	s2
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a3
+process_action_info: a1
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s1
+process_action_info: a2
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s2
+process_action_info: a3
+	iterate_matrix_states: event: e2
+		add_to_action_array: state: s1
+		add_to_action_array: state: s2
+populate_action_array returning false
+found a machine named bar
+	with 2 events and 2 states
+Actions return events
+Translators return void
+The states :
+	0:	s1
+
+	1:	s2
+
+The events :
+	0:	e1
+
+	1:	e2
+
+The actions :
+	a1
+		which occurs for these events
+				e1
+		in these states
+				s1
+		and transitions to state s2
+	a2
+		which occurs for these events
+				e1
+		in these states
+				s2
+	a3
+		which occurs for these events
+				e2
+		in these states
+				s1
+				s2
+		and transitions to state s1
+
+The 2 transitions :
+	s2
+	s1
+
+Found a namespace event reference
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1
+
+	1:	s2
+
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a1
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found an action without transition
+started an action declaration
+The actions in this list:
+	a2
+found a scalar event : e2
+found the beginning of a state comma list
+found a state vector
+	s1
+	s2
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a3
+process_action_info: a1
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s1
+process_action_info: a2
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s2
+process_action_info: a3
+	iterate_matrix_states: event: e2
+		add_to_action_array: state: s1
+		add_to_action_array: state: s2
+populate_action_array returning false
+found a machine named baz
+	with 2 events and 2 states
+Actions return events
+Translators return void
+The states :
+	0:	s1
+
+	1:	s2
+
+The events :
+	0:	e1
+
+	1:	e2
+
+The actions :
+	a1
+		which occurs for these events
+				e1
+		in these states
+				s1
+		and transitions to state s2
+	a2
+		which occurs for these events
+				e1
+		in these states
+				s2
+	a3
+		which occurs for these events
+				e2
+		in these states
+				s1
+				s2
+		and transitions to state s1
+
+The 2 transitions :
+	s2
+	s1
+
+found a scalar event : e2
+found a state scalar
+found a matrix
+found an action matrix
+found an action without transition
+started an action declaration
+The actions in this list:
+	a1
+process_action_info: a1
+	iterate_matrix_states: event: e2
+		add_to_action_array: state: s2
+populate_action_array returning false
+found a machine named foo
+	with 2 events and 2 states
+Actions return events
+Translators return void
+The states :
+	0:	s1; This state is implemented by machine bar.
+
+	1:	s2
+
+The events :
+	0:	e1; This event is shared by 2 sub-machines:
+			bar
+			baz
+
+
+	1:	e2
+
+1 events reference the parent machine.
+The actions :
+	a1
+		which occurs for these events
+				e2
+		in these states
+				s2
+
+The 0 transitions :
+this machine has data
+int i;
+
+this machine has 2 sub-machines
+the sub-machine depth is 1
+
+found a single machine

--- a/test/parser/parser-test53.fsm
+++ b/test/parser/parser-test53.fsm
@@ -1,0 +1,32 @@
+machine foo
+{
+data
+{
+ int i;
+}
+	event e1 data translator foo implemented by machine baz {int i;}, e2;
+	state s1 implemented by machine bar, s2;
+
+	machine bar
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	machine baz
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	action a1[e2, s2];
+}
+

--- a/test/parser/parser-test54.canonical
+++ b/test/parser/parser-test54.canonical
@@ -1,0 +1,213 @@
+found simple data type id
+found data field: TYPE: simple; NAME: i
+Starting data_fields list
+Data block done
+found a data translator: foo
+translator foo implemented by submachine baz
+found simple data type name
+found data field: TYPE: simple; NAME: i
+Starting data_fields list
+Data block done
+found data fields
+int i;
+
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+state s1 implemented by submachine bar
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1; This state is implemented by machine bar.
+
+	1:	s2
+
+Found a namespace event reference
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1
+
+	1:	s2
+
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a1
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found an action without transition
+started an action declaration
+The actions in this list:
+	a2
+found a scalar event : e2
+found the beginning of a state comma list
+found a state vector
+	s1
+	s2
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a3
+process_action_info: a1
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s1
+process_action_info: a2
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s2
+process_action_info: a3
+	iterate_matrix_states: event: e2
+		add_to_action_array: state: s1
+		add_to_action_array: state: s2
+populate_action_array returning false
+found a machine named bar
+	with 2 events and 2 states
+Actions return events
+Translators return void
+The states :
+	0:	s1
+
+	1:	s2
+
+The events :
+	0:	e1
+
+	1:	e2
+
+The actions :
+	a1
+		which occurs for these events
+				e1
+		in these states
+				s1
+		and transitions to state s2
+	a2
+		which occurs for these events
+				e1
+		in these states
+				s2
+	a3
+		which occurs for these events
+				e2
+		in these states
+				s1
+				s2
+		and transitions to state s1
+
+The 2 transitions :
+	s2
+	s1
+
+Found a namespace event reference
+added another id to the event declaration list
+The 2 events in this list:
+	0:	e1
+
+	1:	e2
+
+found the start of a state declaration list
+added another id to the state declaration list
+The 2 states in this list :
+	0:	s1
+
+	1:	s2
+
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a1
+found a scalar event : e1
+found a state scalar
+found a matrix
+found an action matrix
+found an action without transition
+started an action declaration
+The actions in this list:
+	a2
+found a scalar event : e2
+found the beginning of a state comma list
+found a state vector
+	s1
+	s2
+found a matrix
+found an action matrix
+found a transition to known state
+found an action with transition
+started an action declaration
+The actions in this list:
+	a3
+process_action_info: a1
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s1
+process_action_info: a2
+	iterate_matrix_states: event: e1
+		add_to_action_array: state: s2
+process_action_info: a3
+	iterate_matrix_states: event: e2
+		add_to_action_array: state: s1
+		add_to_action_array: state: s2
+populate_action_array returning false
+found a machine named baz
+	with 2 events and 2 states
+Actions return events
+Translators return void
+The states :
+	0:	s1
+
+	1:	s2
+
+The events :
+	0:	e1
+
+	1:	e2
+
+The actions :
+	a1
+		which occurs for these events
+				e1
+		in these states
+				s1
+		and transitions to state s2
+	a2
+		which occurs for these events
+				e1
+		in these states
+				s2
+	a3
+		which occurs for these events
+				e2
+		in these states
+				s1
+				s2
+		and transitions to state s1
+
+The 2 transitions :
+	s2
+	s1
+
+test: parser-test54.fsm: syntax error
+	line 30 : baz

--- a/test/parser/parser-test54.fsm
+++ b/test/parser/parser-test54.fsm
@@ -1,0 +1,42 @@
+machine foo
+{
+data
+{
+ int i;
+}
+	event e1 data translator foo implemented by machine baz {int i;}, e2;
+	state s1 implemented by machine bar, s2;
+
+	machine bar
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	machine baz
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	machine baz
+	{
+		event parent::e1, e2;
+		state s1, s2;
+
+		action a1[e1,s1] transition s2;
+		action a2[e1,s2];
+		action a3[e2, (s1, s2)] transition s1;
+	}
+
+	action a1[e2, s2];
+}
+

--- a/test/statistics/test1.canonical
+++ b/test/statistics/test1.canonical
@@ -6,6 +6,7 @@ number of events: 2
 number of events handled in zero states: 0
 number of events handled in one state: 0
 number of events having data: 0
+number of data translators implemented by machine: 0
 translators return: void
 machine has events with single pai: yes
 number of states: 2

--- a/test/statistics/test2.canonical
+++ b/test/statistics/test2.canonical
@@ -6,6 +6,7 @@ number of events: 3
 number of events handled in zero states: 0
 number of events handled in one state: 2
 number of events having data: 0
+number of data translators implemented by machine: 0
 translators return: void
 machine has events with single pai: no
 number of states: 4

--- a/test/statistics/test3.canonical
+++ b/test/statistics/test3.canonical
@@ -6,6 +6,7 @@ number of events: 3
 number of events handled in zero states: 0
 number of events handled in one state: 2
 number of events having data: 0
+number of data translators implemented by machine: 0
 translators return: void
 machine has events with single pai: no
 number of states: 5

--- a/test/statistics/test4.canonical
+++ b/test/statistics/test4.canonical
@@ -6,6 +6,7 @@ number of events: 3
 number of events handled in zero states: 0
 number of events handled in one state: 2
 number of events having data: 0
+number of data translators implemented by machine: 0
 translators return: void
 machine has events with single pai: no
 number of states: 5

--- a/test/statistics/test6.canonical
+++ b/test/statistics/test6.canonical
@@ -5,8 +5,8 @@ actions return: events
 number of events: 3
 number of events handled in zero states: 0
 number of events handled in one state: 2
-number of events having data: 0
-number of data translators implemented by machine: 0
+number of events having data: 1
+number of data translators implemented by machine: 1
 translators return: void
 machine has events with single pai: no
 number of states: 5
@@ -18,7 +18,8 @@ number of states with no way in: 1
 number of states with no way out: 2
 number of states implemented by machine: 1
 number of actions: 4
-number of sub-machines: 1
+machine has data
+number of sub-machines: 2
 depth of sub-machines: 1
 Action Array:
 Event Name          PAI Count      State Count Avg Use (%) Actions Triggered 
@@ -39,6 +40,36 @@ action a2 [e2, s2] transition s3;
 action a3 [e3, s3] transition tf1;
 
 machine name: testFSM::bar
+reentrance protection:  no
+machine transition: none
+actions return: events
+number of events: 1
+number of events handled in zero states: 0
+number of events handled in one state: 1
+number of events having data translators: 0
+number of data translators implemented by machine: 0
+translators return: void
+machine has events with single pai: yes
+number of states: 1
+number of states with entry fns: 0
+number of states with exit fns: 0
+number of states handling zero events: 0
+number of states handling one event: 1
+number of states with no way in: 0
+number of states with no way out: 1
+number of states implemented by machine: 0
+number of actions: 1
+number of sub-machines: 0
+Action Array:
+Event Name          PAI Count      State Count Avg Use (%) Actions Triggered 
+e1                  single         1           100        a1
+
+State Name           Events Handled Avg Use (%) Transitions (In/Out) Actions Triggered 
+s1                   1              100         0 / 0 none a1
+Action Matrices:
+action a1 [e1, s1];
+
+machine name: testFSM::baz
 reentrance protection:  no
 machine transition: none
 actions return: events

--- a/test/statistics/test6.fsm
+++ b/test/statistics/test6.fsm
@@ -1,0 +1,34 @@
+machine testFSM
+{
+data
+{
+int i;
+}
+
+	event e1, e2, e3 data translator foo implemented by machine baz {int i;};
+	state s1, s2, s3, s4, s5 implemented by machine bar;
+
+	machine bar
+	{
+		state s1;
+		event parent::e1;
+		action a1[e1,s1];
+	}
+
+	machine baz
+	{
+		state s1;
+		event parent::e1;
+		action a1[e1,s1];
+	}
+
+	action a1[e1,s1]	transition s2;
+	action a4[e1,s2];
+	action a2[e2,s2]	transition s3;
+	action a3[e3,s3]	transition tf1;
+
+
+	tf1 returns s4, s3;
+
+}
+


### PR DESCRIPTION
Data translators also benefit from being implemented by respective sub-machines.

The design for this follows that of the "state-implementing" sub-machines.

- A new modFlag is added.
- A "run_" function is generated for each implementing machine.
- Appropriate modifications are made to function signatures to allow user functions to call the "run_" functions as needed.

However, unlike the state-implementing machines, translator-implementers participate in event-sharing.

Some function names were changed to use generic "artifact implementing" language when they are appropriate for both state- and translator-implementers.