### PR TITLE
332 experimental another look at how events should be shared to other machines in a state implemented by a machine

### DIFF
--- a/linux/source.mk
+++ b/linux/source.mk
@@ -21,5 +21,6 @@ SRC =   lexer.c                		\
          fsm_c_single_switch.c 		\
          action_info_list.c    		\
 	 		fsm_python_transitions.c   \
-			parser_support.c
+			parser_support.c           \
+			fsm_c_common_submach.c
 

--- a/src/fsm_c.c
+++ b/src/fsm_c.c
@@ -1561,11 +1561,26 @@ static void declareCMachineStruct(pCMachineData pcmd, pMACHINE_INFO pmi)
 			, generate_instance ? machineName(pcmd) : fqMachineName(pcmd)
 			);
 
-	fprintf(fout
-			, "\t%-*s instance;\n"
-			, (int) pcmd->c_machine_struct_format_width
-			, "unsigned"
-			);
+	if (generate_instance)
+	{
+		fprintf(fout
+				, "\t%-*s instance;\n"
+				, (int) pcmd->c_machine_struct_format_width
+				, "unsigned"
+				);
+	}
+
+	if (!generate_instance
+		&& pcmd->parent_pcmd
+		&& pcmd->parent_pcmd->pmi->states_implemented_by_machine
+		)
+	{
+		fprintf(fout
+				, "\tp%s parent;\n"
+				, fsmType(pcmd->parent_pcmd)
+				);
+
+	}
 
 	if (pmi->data)
 	{

--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -38,6 +38,7 @@
 #include "ancestry.h"
 #include "util_file_inclusion.h"
 #include "revision.h"
+#include "fsm_c_common_submach.h"
 
 #include <stdio.h>
 #include <ctype.h>
@@ -953,6 +954,7 @@ void commonHeaderStart(pFSMCOutputGenerator pfsmcog
 
 		printSubMachinesDeclarations(pcmd, pmi);
 		declare_artifact_implementing_machine_run_functions(pcmd);
+		declare_needed_event_sharing_functions(pfsmcog);
 	}
 
 	/* put the data structure definition into the header */
@@ -962,7 +964,7 @@ void commonHeaderStart(pFSMCOutputGenerator pfsmcog
 		fprintf(pmi->machine_list
 				? generate_instance ? pcmd->subMachineHFile : fout
 				: fout
-				, "struct _%s_data_struct_ {\n"
+				, "\nstruct _%s_data_struct_ {\n"
 				, generate_instance ? machineName(pcmd) : fqMachineName(pcmd)
 			   );
 
@@ -1268,7 +1270,9 @@ void generateInstance(pCMachineData pcmd
 			   );
 	}
 
-	if (pmi->parent != NULL)
+	if ((pmi->parent != NULL)
+		|| (pmi->states_implemented_by_machine)
+		)
 	{
 
 		fprintf(pcmd->cFile
@@ -1347,6 +1351,12 @@ void generateInstanceMacro(pCMachineData pcmd
 
 	fprintf(pcmd->pubHFile
 			, ")\\\n"
+		   );
+
+	/* Forward declare our pointer so that sub-machines can reference it. */
+	fprintf(pcmd->pubHFile
+			, "static %s A;\\\n"
+			, fsmType(pcmd)
 		   );
 
 	// we need to invoke each sub-machine macro
@@ -1480,8 +1490,9 @@ void generateSubMachineInstanceMacro(pCMachineData pcmd
 		   );
 
 	fprintf(pcmd->parent_pcmd->instanceMacrosHFile
-			, "#define %s_INSTANCE(A%s"
+			, "#define %s_INSTANCE(A%s%s"
 			, ucfqMachineName(pcmd)
+			, pmi->parent->states_implemented_by_machine ? ", PARENT_PTR" : ""
 			, pmi->data ? ", B" : ""
 		   );
 
@@ -1531,6 +1542,14 @@ void generateSubMachineInstanceMacro(pCMachineData pcmd
 			, stateEnumMemberPmi(stateNameByIndex(pmi, 0), pmi, &cp)
 		   );
 	CHECK_AND_FREE(cp);
+
+	if (pcmd->parent_pcmd->pmi->states_implemented_by_machine)
+	{
+		fprintf(pcmd->parent_pcmd->instanceMacrosHFile
+				, "\t, .parent = (p%s) (PARENT_PTR)\\\n"
+				, fsmType(pcmd->parent_pcmd)
+				);
+	}
 
 	fprintf(pcmd->parent_pcmd->instanceMacrosHFile
 			, "\t, .event = %s_%s\\\n"
@@ -3769,7 +3788,7 @@ bool define_event_passing_actions(pLIST_ELEMENT pelem, void *data)
 		{
 			fprintf(pich->pcmd->cFile
 					, "%s UFMN(%s)(p%s pfsm)\n{\n"
-					, pich->pcmd->pmi->modFlags & mfActionsReturnStates
+					, pich->pcmd->pmi->modFlags & ACTIONS_RETURN_FLAGS
 					? actionReturnType(pich->pcmd)
 					: subFsmFnReturnType(pich->pcmd)
 					, pid_info->name
@@ -3799,6 +3818,36 @@ bool define_event_passing_actions(pLIST_ELEMENT pelem, void *data)
 					? "\treturn STATE(noTransition);\n"
 					: ""
 				   );
+		}
+		else if (ped->shared_with_parent
+				 && (pich->ih.pmi->modFlags & mfStateImplementing)
+				 && iterate_list(ped->parent_event->type_data.event_data.psharing_sub_machines, find_legitimate_sharer, pich)
+				 )
+		{
+			fprintf(pich->pcmd->cFile
+					, "%s UFMN(%s)(p%s pfsm)\n{\n"
+					, pich->pcmd->pmi->modFlags & ACTIONS_RETURN_FLAGS
+					? actionReturnType(pich->pcmd)
+					: subFsmFnReturnType(pich->pcmd)
+					, pid_info->name
+					, fsmType(pich->pcmd)
+				   );
+
+			fprintf(pich->pcmd->cFile
+					, "\t%s(\"%s%%s\", __func__);\n"
+					, core_logging_only ? "NON_CORE_DEBUG_PRINTF" : "DBG_PRINTF"
+					, force_generation_of_event_passing_actions ? "" : "weak: "
+				   );
+
+			fprintf(pich->pcmd->cFile
+					, "\t%sshare_parent_event_%s(pfsm->%s);\n}\n\n"
+					, pich->pcmd->pmi->modFlags & ACTIONS_RETURN_FLAGS
+					  ? ""
+					  : "return "
+					, pevent->name
+					, generate_instance ? "instance" : "parent"
+					);
+
 		}
 
 	}
@@ -4985,8 +5034,9 @@ static bool possibly_invoke_sub_machine_macro(pLIST_ELEMENT pelem, void *data)
 	char          *name;
 
 	fprintf(pcmd->parent_pcmd ? pcmd->parent_pcmd->instanceMacrosHFile : pcmd->pubHFile
-			, "%s_INSTANCE(A"
+			, "%s_INSTANCE(A%s"
 			, ucfqMachineNamePmi(pmi, &name)
+			, pmi->parent->states_implemented_by_machine ?  ", &(A)" : ""
 		   );
 	CHECK_AND_FREE(name);
 

--- a/src/fsm_c_common.c
+++ b/src/fsm_c_common.c
@@ -3840,12 +3840,15 @@ bool define_event_passing_actions(pLIST_ELEMENT pelem, void *data)
 				   );
 
 			fprintf(pich->pcmd->cFile
-					, "\t%sshare_parent_event_%s(pfsm->%s);\n}\n\n"
+					, "\t%sshare_parent_event_%s(pfsm->%s);\n%s}\n\n"
 					, pich->pcmd->pmi->modFlags & ACTIONS_RETURN_FLAGS
 					  ? ""
 					  : "return "
 					, pevent->name
 					, generate_instance ? "instance" : "parent"
+					, pich->pcmd->pmi->modFlags & mfActionsReturnStates
+					  ? "\treturn STATE(noTransition);\n"
+					  : ""
 					);
 
 		}

--- a/src/fsm_c_common_submach.c
+++ b/src/fsm_c_common_submach.c
@@ -1,0 +1,193 @@
+/**
+*  fsm_c_common_submach.c
+*
+*    Submachine related common C stuff.
+*
+*    FSMLang (fsm) - A Finite State Machine description language.
+*    Copyright (C) 2026  Steven Stanton
+*
+*    This program is free software; you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation; either version 2 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program; if not, write to the Free Software
+*    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*
+*    Steven Stanton
+*    fsmlang@pesticidesoftware.com
+*
+*    For the latest on FSMLang: https://fsmlang.github.io
+*
+*    And, finally, your possession of this source code implies nothing.
+*
+*    File created by Steven Stanton
+*
+*  Long Description:
+*
+*/
+
+#include "fsm_c_common_submach.h"
+#include "ancestry.h"
+#include "list.h"
+
+#if defined (CYGWIN) || defined (LINUX)
+	#include <stdio.h>
+	#include <ctype.h>
+	#include <unistd.h>
+#endif
+#if defined (LINUX) || defined (VS) || defined (CYGWIN)
+	#include <time.h>
+#endif
+#include <string.h>
+#include <stdlib.h>
+
+static void print_parent_event_sharer_signature(pCMachineData,pID_INFO,FILE*,DECLARE_OR_DEFINE);
+static bool define_needed_parent_event_sharers(pLIST_ELEMENT, void *);
+static bool declare_needed_parent_event_sharers(pLIST_ELEMENT, void *);
+
+/**
+ * Print the signature of the parent event sharing function,
+ * suitable for a declaration or the start of the definition.
+ * 
+ * @author Steven Stanton (8/27/2026)
+ * 
+ * @param pcmd   Data from the governing Output Generator
+ * @param fout   Destination file
+ * @param dod    Print for declaration when dod == dod_declare;
+ *  			 otherwise, print for start of definition.
+ */
+static void print_parent_event_sharer_signature(pCMachineData pcmd, pID_INFO pevent, FILE *fout, DECLARE_OR_DEFINE dod)
+{
+	fprintf(fout
+			, "%s share_parent_event_%s(unsigned%s)%s\n"
+			, eventType(pcmd)
+			, pevent->name
+			, dod == dod_declare ? "" : " instance"
+			, dod == dod_declare ? ";" : "\n{"
+			);
+}
+
+bool find_legitimate_sharer(pLIST_ELEMENT pelem, void *data)
+{
+	pMACHINE_INFO             pmi  = (pMACHINE_INFO) pelem->mbr;
+	pITERATOR_CALLBACK_HELPER pich = (pITERATOR_CALLBACK_HELPER) data;
+
+	return (
+			(pmi != pich->ih.pmi)
+			&& (!(pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS))
+			);
+}
+
+
+/**
+ * Create switch cases for each event that a parent shares to
+ * other machines.
+ * 
+ * @author Steven Stanton (8/26/2026)
+ * 
+ * @param pelem  The event record
+ * @param data   Must be a pointer to an
+ *  			 ITERATOR_CALLBACK_HELPER.
+ * 
+ * @return bool Always "false."
+ */
+static bool define_needed_parent_event_sharers(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO                  pevent = (pID_INFO) pelem->mbr;
+	pITERATOR_CALLBACK_HELPER pich   = (pITERATOR_CALLBACK_HELPER) data;
+
+	pEVENT_DATA ped = &pevent->type_data.event_data;
+
+	pich->ih.pid = pevent;
+
+	if (ped->psharing_sub_machines
+		&& iterate_list(ped->psharing_sub_machines, find_legitimate_sharer, pich)
+		)
+	{
+		print_parent_event_sharer_signature(pich->pcmd, pevent, pich->ih.fout, dod_define);
+
+		fprintf(pich->ih.fout
+				, "\tp%s pfsm = %s_INSTANCES[instance];\n"
+				  "\treturn %s_pass_shared_event(pfsm, sharing_%s_%s);\n"
+				, fsmType(pich->pcmd)
+				, machineName(pich->pcmd)
+				, machineName(pich->pcmd)
+				, machineName(pich->pcmd)
+				, pevent->name
+				);
+
+		fprintf(pich->ih.fout
+				, "}\n\n"
+				);
+	}
+
+	return false;
+}
+
+static bool declare_needed_parent_event_sharers(pLIST_ELEMENT pelem, void *data)
+{
+	pID_INFO                  pevent = (pID_INFO) pelem->mbr;
+	pITERATOR_CALLBACK_HELPER pich   = (pITERATOR_CALLBACK_HELPER) data;
+
+	pEVENT_DATA ped = &pevent->type_data.event_data;
+
+	pich->ih.pid = pevent;
+
+	if (ped->psharing_sub_machines
+		&& iterate_list(ped->psharing_sub_machines, find_legitimate_sharer, pich)
+		)
+	{
+		print_parent_event_sharer_signature(pich->pcmd
+											, pevent
+											, pich->ih.fout
+											, dod_declare
+											);
+
+	}
+
+	return false;
+}
+
+void define_needed_event_sharing_functions(pFSMCOutputGenerator pfsmcog)
+{
+	
+	ITERATOR_CALLBACK_HELPER ich = {
+		.ih = {
+			.pmi = pfsmcog->pcmd->pmi
+			, .fout = pfsmcog->pcmd->cFile
+		}
+		, .pcmd = pfsmcog->pcmd
+	};
+
+	iterate_list(pfsmcog->pcmd->pmi->event_list
+				 , define_needed_parent_event_sharers
+				 , &ich
+				 );
+
+}
+
+void declare_needed_event_sharing_functions(pFSMCOutputGenerator pfsmcog)
+{
+	
+	ITERATOR_CALLBACK_HELPER ich = {
+		.ih = {
+			.pmi = pfsmcog->pcmd->pmi
+			, .fout = pfsmcog->pcmd->subMachineHFile
+		}
+		, .pcmd = pfsmcog->pcmd
+	};
+
+	iterate_list(pfsmcog->pcmd->pmi->event_list
+				 , declare_needed_parent_event_sharers
+				 , &ich
+				 );
+
+}
+

--- a/src/fsm_c_common_submach.c
+++ b/src/fsm_c_common_submach.c
@@ -67,7 +67,7 @@ static void print_parent_event_sharer_signature(pCMachineData pcmd, pID_INFO pev
 {
 	fprintf(fout
 			, "%s share_parent_event_%s(%s%s%s)%s\n"
-			, eventType(pcmd)
+			, subFsmFnReturnType(pcmd)
 			, pevent->name
 			, generate_instance ? "unsigned" : "p"
 			, generate_instance ? "" : fsmType(pcmd)
@@ -130,7 +130,8 @@ static bool define_needed_parent_event_sharers(pLIST_ELEMENT pelem, void *data)
 		}
 
 		fprintf(pich->ih.fout
-				, "\treturn %s_pass_shared_event(pfsm, sharing_%s_%s);\n"
+				, "\t%s%s_pass_shared_event(pfsm, sharing_%s_%s);\n"
+				, pich->pcmd->pmi->modFlags & ACTIONS_RETURN_FLAGS ? "" : "return "
 				, machineName(pich->pcmd)
 				, machineName(pich->pcmd)
 				, pevent->name

--- a/src/fsm_c_common_submach.c
+++ b/src/fsm_c_common_submach.c
@@ -66,10 +66,15 @@ static bool declare_needed_parent_event_sharers(pLIST_ELEMENT, void *);
 static void print_parent_event_sharer_signature(pCMachineData pcmd, pID_INFO pevent, FILE *fout, DECLARE_OR_DEFINE dod)
 {
 	fprintf(fout
-			, "%s share_parent_event_%s(unsigned%s)%s\n"
+			, "%s share_parent_event_%s(%s%s%s)%s\n"
 			, eventType(pcmd)
 			, pevent->name
-			, dod == dod_declare ? "" : " instance"
+			, generate_instance ? "unsigned" : "p"
+			, generate_instance ? "" : fsmType(pcmd)
+			, dod == dod_declare
+			  ? ""
+			  : generate_instance
+				? " instance" : " pfsm"
 			, dod == dod_declare ? ";" : "\n{"
 			);
 }
@@ -81,7 +86,8 @@ bool find_legitimate_sharer(pLIST_ELEMENT pelem, void *data)
 
 	return (
 			(pmi != pich->ih.pmi)
-			&& (!(pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS))
+			&& (!(pmi->modFlags & mfStateImplementing))
+			&& (!(pmi->modFlags & ACTIONS_RETURN_FLAGS))
 			);
 }
 
@@ -108,16 +114,23 @@ static bool define_needed_parent_event_sharers(pLIST_ELEMENT pelem, void *data)
 	pich->ih.pid = pevent;
 
 	if (ped->psharing_sub_machines
+//		&& (pich->ih.pmi->modFlags & mfStateImplementing)
 		&& iterate_list(ped->psharing_sub_machines, find_legitimate_sharer, pich)
 		)
 	{
 		print_parent_event_sharer_signature(pich->pcmd, pevent, pich->ih.fout, dod_define);
 
+		if (generate_instance)
+		{
+			fprintf(pich->ih.fout
+					, "\tp%s pfsm = %s_INSTANCES[instance];\n"
+					, fsmType(pich->pcmd)
+					, machineName(pich->pcmd)
+					);
+		}
+
 		fprintf(pich->ih.fout
-				, "\tp%s pfsm = %s_INSTANCES[instance];\n"
-				  "\treturn %s_pass_shared_event(pfsm, sharing_%s_%s);\n"
-				, fsmType(pich->pcmd)
-				, machineName(pich->pcmd)
+				, "\treturn %s_pass_shared_event(pfsm, sharing_%s_%s);\n"
 				, machineName(pich->pcmd)
 				, machineName(pich->pcmd)
 				, pevent->name
@@ -141,6 +154,7 @@ static bool declare_needed_parent_event_sharers(pLIST_ELEMENT pelem, void *data)
 	pich->ih.pid = pevent;
 
 	if (ped->psharing_sub_machines
+//		&& (pich->ih.pmi->modFlags & mfStateImplementing)
 		&& iterate_list(ped->psharing_sub_machines, find_legitimate_sharer, pich)
 		)
 	{
@@ -179,7 +193,9 @@ void declare_needed_event_sharing_functions(pFSMCOutputGenerator pfsmcog)
 	ITERATOR_CALLBACK_HELPER ich = {
 		.ih = {
 			.pmi = pfsmcog->pcmd->pmi
-			, .fout = pfsmcog->pcmd->subMachineHFile
+			, .fout = generate_instance
+			          ? pfsmcog->pcmd->subMachineHFile
+					  : pfsmcog->pcmd->pubHFile
 		}
 		, .pcmd = pfsmcog->pcmd
 	};

--- a/src/fsm_c_common_submach.h
+++ b/src/fsm_c_common_submach.h
@@ -1,0 +1,47 @@
+/**
+*  fsm_c_common_submach.h
+*
+*    Submachine related common C stuff.
+*
+*    FSMLang (fsm) - A Finite State Machine description language.
+*    Copyright (C) 2026  Steven Stanton
+*
+*    This program is free software; you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation; either version 2 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program; if not, write to the Free Software
+*    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*
+*    Steven Stanton
+*    fsmlang@pesticidesoftware.com
+*
+*    For the latest on FSMLang: https://fsmlang.github.io
+*
+*    And, finally, your possession of this source code implies nothing.
+*
+*    File created by Steven Stanton
+*
+*  Long Description:
+*
+*/
+
+#ifndef FSM_C_COMMON_SUBMACH_H
+#define FSM_C_COMMON_SUBMACH_H
+
+#include "fsm_c_common.h"
+
+void define_needed_event_sharing_functions(pFSMCOutputGenerator);
+void declare_needed_event_sharing_functions(pFSMCOutputGenerator);
+
+bool find_legitimate_sharer(pLIST_ELEMENT,void*);
+
+#endif
+

--- a/src/fsm_c_event_table.c
+++ b/src/fsm_c_event_table.c
@@ -520,6 +520,18 @@ static void defineCEventTableMachineStruct(pCMachineData pcmd)
 			   );
    }
 
+   if (!generate_instance
+	   && pcmd->parent_pcmd
+	   && pcmd->parent_pcmd->pmi->states_implemented_by_machine
+	   )
+   {
+	   fprintf(fout
+			   , "\tp%s parent;\n"
+			   , fsmType(pcmd->parent_pcmd)
+			   );
+	   
+   }
+
    if (pmi->data)
    {
       fprintf(fout

--- a/src/fsm_c_single_switch.c
+++ b/src/fsm_c_single_switch.c
@@ -401,6 +401,18 @@ static void defineCSingleSwitchMachineStruct(pCMachineData pcmd)
 			   );
    }
 
+   if (!generate_instance
+	   && pcmd->parent_pcmd
+	   && pcmd->parent_pcmd->pmi->states_implemented_by_machine
+	   )
+   {
+	   fprintf(fout
+			   , "\tp%s parent;\n"
+			   , fsmType(pcmd->parent_pcmd)
+			   );
+	   
+   }
+
    if (pmi->data)
    {
       fprintf(fout

--- a/src/fsm_cswitch.c
+++ b/src/fsm_cswitch.c
@@ -38,6 +38,7 @@
 #include "fsm_c_switch_common.h"
 #include "fsm_unused.h"
 #include "ancestry.h"
+#include "fsm_c_common_submach.h"
 
 #if defined (CYGWIN) || defined (LINUX)
 #include <stdio.h>
@@ -614,6 +615,11 @@ static int writeCSwitchMachineInternal(pFSMCOutputGenerator pfsmcog)
 
    define_artifact_implementing_machine_run_functions(pcmd);
 
+   if (pmi->states_implemented_by_machine)
+   {
+	   define_needed_event_sharing_functions(pfsmcog);
+   }
+
    writeDebugInfo(pcmd, pmi);
 
 	addNativeImplementationEpilogIfThereIsAny(pmi, pcmd->cFile);
@@ -833,12 +839,27 @@ static void defineCSwitchMachineStruct(pCMachineData pcmd, pMACHINE_INFO pmi)
 		   , generate_instance ? machineName(pcmd) : fqMachineName(pcmd)
 		   );
 
-   fprintf(fout
-		   , "\t%-*s instance;\n"
-		   , (int) pcmd->sub_machine_struct_format_width
-		   , "unsigned"
-		   );
-   
+   if (generate_instance)
+   {
+	   fprintf(fout
+			   , "\t%-*s instance;\n"
+			   , (int) pcmd->sub_machine_struct_format_width
+			   , "unsigned"
+			   );
+   }
+
+   if (!generate_instance
+	   && pcmd->parent_pcmd
+	   && pcmd->parent_pcmd->pmi->states_implemented_by_machine
+	   )
+   {
+	   fprintf(fout
+			   , "\tp%s parent;\n"
+			   , fsmType(pcmd->parent_pcmd)
+			   );
+	   
+   }
+
    if (pmi->data)
    {
       fprintf(fout
@@ -1526,8 +1547,8 @@ static bool print_event_returning_state_fn_case(pLIST_ELEMENT pelem, void *data)
 					, pevent->name
 					);
 
-			if ((pich->ih.pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
-				&& pevent->type_data.event_data.shared_with_parent
+			if (pevent->type_data.event_data.shared_with_parent
+				&& (pich->ih.pmi->modFlags & ARTIFACTS_IMPLEMENTING_FLAGS)
 				)
 			{
 				fprintf(pich->pcmd->cFile
@@ -2171,8 +2192,12 @@ static bool print_switch_cases_for_events_handled_in_all_states_arev(pLIST_ELEME
       pich->counter++;
 
       fprintf(pich->pcmd->cFile
-			  , "\t\tcase %s_%s:\n"
-			  , fqMachineName(pich->pcmd)
+			  , "\t\tcase %s(%s):\n"
+			  , (ped->shared_with_parent
+				  && (pich->ih.pmi->modFlags & mfStateImplementing)
+				  )
+				? "PARENT"
+				: "THIS"
 			  , event->name
 			  );
 

--- a/src/fsm_priv.h
+++ b/src/fsm_priv.h
@@ -197,6 +197,7 @@ struct _event_data_
    pID_INFO         externalDesignation;
    pLIST            psharing_sub_machines;
    bool             shared_with_parent;
+   pID_INFO         parent_event;
    unsigned         state_implementing_sharer_count;
    unsigned         translator_implementing_sharer_count;
    unsigned         single_pai_state_count;
@@ -424,6 +425,7 @@ struct _machine_info_ {
   unsigned      average_state_event_density_pct;
   unsigned      average_event_state_density_pct;
   pLIST         sequences;
+  pID_INFO      implemented_state;
 };
 
 /* lexer id list handlers */

--- a/src/fsm_utils.c
+++ b/src/fsm_utils.c
@@ -498,7 +498,7 @@ static bool iterate_matrix_states(pLIST_ELEMENT pelem, void *data)
    paaph->error = false;
    iterate_list(paaph->pai->matrix->state_list,add_to_action_array,paaph);
 
-   if (ped->single_pai_state_count == (paaph->pmi->state_list->count - paaph->pmi->states_implemented_by_machine))
+   if (ped->single_pai_state_count == paaph->pmi->state_list->count)
    {
       ped->single_pai_for_all_states    = true;
       paaph->pmi->has_single_pai_events = true;

--- a/src/parser.y
+++ b/src/parser.y
@@ -1991,6 +1991,7 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
 
            pid->type_data.event_data.puser_event_data   = $5;
            pid->type_data.event_data.shared_with_parent = true;
+           pid->type_data.event_data.parent_event       = $3;
            pid->powningMachine                          = pmachineInfo;
  					pid->docCmnt                                 = $2;
 
@@ -2076,6 +2077,7 @@ event_decl_list:	EVENT_KEY ID external_designation user_event_data
 
            pid->type_data.event_data.puser_event_data    = $6;
            pid->type_data.event_data.shared_with_parent  = true;
+           pid->type_data.event_data.parent_event        = $4;
            pid->powningMachine                           = pmachineInfo;
  					 pid->docCmnt                                  = $3;
 

--- a/src/parser_support.c
+++ b/src/parser_support.c
@@ -263,6 +263,7 @@ pMACHINE_PREFIX machine_declared_by_machine_pid(pNATIVE_INFO pnative, MOD_FLAGS 
 	}
 
 	machine_pid->type_data.machine_pid_data.pmi = pmachine_prefix->pmachineInfo;
+	pmachine_prefix->pmachineInfo->implemented_state = machine_pid->type_data.machine_pid_data.implementedArtifact;
 
 	return pmachine_prefix;
 }

--- a/test/full_test148/test_fsm_submach.h.canonical
+++ b/test/full_test148/test_fsm_submach.h.canonical
@@ -51,6 +51,8 @@ extern TEST_FSM_SHARED_EVENT_STR sub2_share_test_fsm_e1_str;
 extern pTEST_FSM_SHARED_EVENT_STR sharing_test_fsm_e1[];
 
 
+TEST_FSM_EVENT_ENUM share_parent_event_e1(unsigned);
+
 struct _test_fsm_data_struct_ {
 	int e1_count;
 };

--- a/test/full_test153/first_connection-actions.c
+++ b/test/full_test153/first_connection-actions.c
@@ -1,13 +1,13 @@
 #include "first_connection_priv.h"
 
-ACTION_RETURN_TYPE UFMN(start_auth1)(FSM_TYPE_PTR pfsm)
+ACTION_RETURN_TYPE UFMN(act_start_auth1)(FSM_TYPE_PTR pfsm)
 {
 	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return THIS(noEvent);
 }
 
-ACTION_RETURN_TYPE UFMN(start_auth2)(FSM_TYPE_PTR pfsm)
+ACTION_RETURN_TYPE UFMN(act_start_auth2)(FSM_TYPE_PTR pfsm)
 {
 	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
@@ -19,6 +19,20 @@ ACTION_RETURN_TYPE UFMN(start_data_sync)(FSM_TYPE_PTR pfsm)
 	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(share_parent_start_auth1)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return PARENT(start_auth1);
+}
+
+ACTION_RETURN_TYPE UFMN(report_done)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return PARENT(peer_data_synced);
 }
 
 ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)

--- a/test/full_test153/first_connection.fsms
+++ b/test/full_test153/first_connection.fsms
@@ -21,9 +21,11 @@ native impl
 	event activate data translator grab_parent_data_ptrs;
 
 	event parent::peer_connected;
+	event parent::start_auth1;
 	event parent::auth1_complete;
 	event parent::auth2_complete;
 	event parent::peer_data_synced;
+	event parent::ble_comm;
 
 	state initial;
 	state waiting;
@@ -34,9 +36,14 @@ native impl
 
 	transition              [activate, initial] waiting;
 
-	action start_auth1      [peer_connected, waiting] transition auth1;
-	action start_auth2      [auth1_complete, auth1] transition auth2;
-	action start_data_sync  [auth2_complete, auth2] transition data_sync;
-	transition              [peer_data_synced, data_sync] done;
+	action act_start_auth1  [peer_connected, waiting]     transition auth1;
+	action act_start_auth2  [auth1_complete, auth1]       transition auth2;
+	action start_data_sync  [auth2_complete, auth2]       transition data_sync;
+	action report_done      [peer_data_synced, data_sync] transition done;
+
+	/* forward to peer sub-machines. */
+	action share_parent_start_auth1 [start_auth1, (all)];
+	action share_parent_ble_comm    [ble_comm, (all)];
+
 }
 

--- a/test/full_test153/test.canonical
+++ b/test/full_test153/test.canonical
@@ -54,7 +54,8 @@ end state: communicator_first_connection_waiting
 end state: communicator_first_time_connect
 communicator_grab_ble_comm
 event: communicator_ble_comm; state: communicator_first_time_connect
-communicator_forward_ble_comm
+event: communicator_ble_comm; state: communicator_first_connection_waiting
+communicator_first_connection_share_parent_ble_comm
 communicator_ble_translate_ble_comm
 event: communicator_ble_adv_packet; state: communicator_ble_scanning
 communicator_ble_parse_adv_packet
@@ -63,14 +64,13 @@ communicator_ble_report_connection
 communicator_ble_stop_scanning
 communicator_ble_set_defaults
 end state: communicator_ble_waiting
-event: communicator_peer_connected; state: communicator_first_time_connect
 event: communicator_peer_connected; state: communicator_first_connection_waiting
-communicator_first_connection_start_auth1
+communicator_first_connection_act_start_auth1
 end state: communicator_first_connection_auth1
 end state: communicator_first_time_connect
 event: communicator_auth1_complete; state: communicator_first_time_connect
 event: communicator_auth1_complete; state: communicator_first_connection_auth1
-communicator_first_connection_start_auth2
+communicator_first_connection_act_start_auth2
 end state: communicator_first_connection_auth2
 end state: communicator_first_time_connect
 event: communicator_auth2_complete; state: communicator_first_time_connect
@@ -80,8 +80,10 @@ end state: communicator_first_connection_data_sync
 end state: communicator_first_time_connect
 event: communicator_peer_data_synced; state: communicator_first_time_connect
 event: communicator_peer_data_synced; state: communicator_first_connection_data_sync
-communicator_first_connection_noAction
+communicator_first_connection_report_done
 end state: communicator_first_connection_done
+event: communicator_peer_data_synced; state: communicator_connected_to_peer
+communicator_noAction
 end state: communicator_connected_to_peer
 
 test: connect_happy_path

--- a/test/full_test153/test_fsm.fsm
+++ b/test/full_test153/test_fsm.fsm
@@ -65,12 +65,6 @@ data
 	action forward_command  [command, waiting];
 	action start_looking    [configuration_complete, waiting] transition first_time_connect;
 
-	/*
-	action forward_peer_connected [peer_connected, first_time_connect];
-	action forward_auth1_complete [auth1_complete, first_time_connect];
-	action forward_auth2_complete [auth2_complete, first_time_connect];
-	action forward_peer_data_synced [peer_data_synced, first_time_connect] transition connected_to_peer;
-	*/
 	transition [peer_data_synced, first_time_connect] connected_to_peer;
 
 	action forward_ble_comm [ble_comm, (all)];

--- a/test/full_test154/Makefile
+++ b/test/full_test154/Makefile
@@ -12,7 +12,10 @@ override CFLAGS += -I../                  \
     -DCOMMUNICATOR_DEBUG                  \
     -DCOMMUNICATOR_COMMANDS_DEBUG         \
     -DCOMMUNICATOR_BLE_DEBUG              \
-    -DCOMMUNICATOR_FIRST_CONNECTION_DEBUG
+    -DCOMMUNICATOR_FIRST_CONNECTION_DEBUG \
+    -DCOMMUNICATOR_AUTH1_DEBUG            \
+    -DCOMMUNICATOR_AUTH2_DEBUG            \
+    -DCOMMUNICATOR_SYNC_DEBUG 
 
 
 override DIFF_FLAGS= -I \"warning: (test_fsm_sub_subSub): all events are handled identically in all states.\"  \

--- a/test/full_test154/auth1-actions.c
+++ b/test/full_test154/auth1-actions.c
@@ -1,0 +1,20 @@
+#include "auth1_priv.h"
+
+ACTION_RETURN_TYPE UFMN(report_auth1_complete)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+
+	(void) pfsm;
+
+	return PARENT(auth1_complete);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+
+	(void) pfsm;
+
+	return THIS(noEvent);
+}
+

--- a/test/full_test154/auth1.fsms
+++ b/test/full_test154/auth1.fsms
@@ -1,0 +1,25 @@
+/**
+	This machine handles the auth1 chores.
+*/
+machine auth1
+native impl
+{
+#define FSM_ENTRY(A)
+#define FSM_EXIT(A) DBG_PRINTF("end state: %s", AUTH1_STATE_NAMES[(A)->state])
+#define ACTION_ENTRY(A)
+#define ACTION_EXIT(A)
+}
+{
+	state initial;
+	state active;
+	state done;
+
+	event parent::activate;
+	event parent::start_auth1;
+	event parent::auth1_gatt;
+
+	transition [activate, (all)] active;
+	action report_auth1_complete[auth1_gatt, active] transition done;
+
+}
+

--- a/test/full_test154/auth2-actions.c
+++ b/test/full_test154/auth2-actions.c
@@ -1,0 +1,20 @@
+#include "auth2_priv.h"
+
+ACTION_RETURN_TYPE UFMN(report_auth2_complete)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+
+	(void) pfsm;
+
+	return PARENT(auth2_complete);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+
+	(void) pfsm;
+
+	return THIS(noEvent);
+}
+

--- a/test/full_test154/auth2.fsms
+++ b/test/full_test154/auth2.fsms
@@ -1,0 +1,25 @@
+/**
+	This machine handles the auth2 chores.
+*/
+machine auth2
+native impl
+{
+#define FSM_ENTRY(A)
+#define FSM_EXIT(A) DBG_PRINTF("end state: %s", AUTH2_STATE_NAMES[(A)->state])
+#define ACTION_ENTRY(A)
+#define ACTION_EXIT(A)
+}
+{
+	state initial;
+	state active;
+	state done;
+
+	event parent::activate;
+	event parent::start_auth2;
+	event parent::auth2_gatt;
+
+	transition [activate, (all)] active;
+	action report_auth2_complete[auth2_gatt, active] transition done;
+
+}
+

--- a/test/full_test154/ble-actions.c
+++ b/test/full_test154/ble-actions.c
@@ -4,7 +4,7 @@ TRANSLATOR_RETURN_TYPE UFMN(grab_parent_data_ptrs)(FSM_DATA_PTR pfsm_data, PAREN
 {
 	DBG_PRINTF("%s", __func__);
 	
-	pfsm_data->pconfiguration = &pparent_data->configuration;
+	pfsm_data->pconfiguration   = &pparent_data->configuration;
 
 	return THIS(activate);
 }
@@ -16,6 +16,8 @@ TRANSLATOR_RETURN_TYPE UFMN(translate_ble_comm)(FSM_DATA_PTR pfsm_data, PARENT_D
 	(void) pfsm_data;
 
 	ACTION_RETURN_TYPE ret;
+
+	pfsm_data->pcurr_ble_event = pparent_data->pcurr_ble_event;
 
 	switch (pparent_data->pcurr_ble_event->type)
 	{
@@ -51,12 +53,19 @@ TRANSLATOR_RETURN_TYPE UFMN(check_configuration)(FSM_DATA_PTR pfsm_data, pCOMMUN
 	else if ((pconfiguration->config_bits & CONNECT_BITS) == CONNECT_BITS)
 		return THIS(do_connect);
 	else
-		return THIS(noEvent); //This line should not be reached; we should only be executing this function when the configuration has reached
-                            // the scan or connect state.
+		return THIS(noEvent); //This line should not be reached; we should only be executing this function
+                            // when the configuration has reached the scan or connect state.
 }
 
 
 ACTION_RETURN_TYPE UFMN(parse_adv_packet)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s",__func__);
+	(void) pfsm;
+	return THIS(connection);
+}
+
+ACTION_RETURN_TYPE UFMN(look_for_peer)(FSM_TYPE_PTR pfsm)
 {
 	DBG_PRINTF("%s",__func__);
 	(void) pfsm;
@@ -68,6 +77,27 @@ ACTION_RETURN_TYPE UFMN(report_connection)(FSM_TYPE_PTR pfsm)
 	DBG_PRINTF("%s",__func__);
 	(void) pfsm;
 	return PARENT(peer_connected);
+}
+
+ACTION_RETURN_TYPE UFMN(report_gatt_characteristic)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s",__func__);
+	switch (pfsm->data.pcurr_ble_event->data.gatt_msg.characteristic)
+	{
+	case AUTH1_GATT:
+		return PARENT(auth1_gatt);
+		break;
+	case AUTH2_GATT:
+		return PARENT(auth2_gatt);
+		break;
+	case SYNC_GATT:
+		return PARENT(sync_gatt);
+		break;
+	default:
+		return THIS(noEvent);
+		break;
+	}
+	
 }
 
 ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)

--- a/test/full_test154/ble.fsms
+++ b/test/full_test154/ble.fsms
@@ -22,12 +22,13 @@ native impl
 	data
 	{
 		pconfiguration_str pconfiguration;
-		pble_event_str     *ppcurr_ble_event;
+		pble_event_str     pcurr_ble_event;
 	}
 
 	event parent::activate data translator grab_parent_data_ptrs;
 	event parent::ble_comm consuming data translator translate_ble_comm;
 	event parent::configuration_complete consuming data translator check_configuration;
+	event parent::comm_window_timer_expired;
 
 	event do_scan;
 	event do_connect;
@@ -55,6 +56,9 @@ native impl
 	transition [do_connect, waiting] waiting_for_connection_window;
 
 	action parse_adv_packet[adv_packet, scanning];
-	action report_connection [connection, scanning] transition waiting;
+	action look_for_peer[comm_window_timer_expired, waiting_for_connection_window];
+	action report_connection [connection, (scanning, waiting_for_connection_window)] transition waiting;
+	action report_gatt_characteristic [gatt_msg, waiting];
+
 }
 

--- a/test/full_test154/ble_defs.h
+++ b/test/full_test154/ble_defs.h
@@ -13,8 +13,12 @@ typedef enum
 	, ble_num_entries
 } ble_event_e;
 
-#define GATT_MSG_SIZE   252  //Accuracy is not important here.
-#define ADV_PACKET_SIZE 252  //Accuracy is not important here.
+#define GATT_MSG_SIZE   252
+#define ADV_PACKET_SIZE 252
+
+#define AUTH1_GATT 0x0001
+#define AUTH2_GATT 0x0002
+#define SYNC_GATT  0x0003
 
 typedef struct _gatt_message_str_ gatt_message_str, *pgatt_message_str;
 typedef union  _ble_event_data_u_ ble_event_data, *pble_event_data;

--- a/test/full_test154/first_connection-actions.c
+++ b/test/full_test154/first_connection-actions.c
@@ -1,13 +1,13 @@
 #include "first_connection_priv.h"
 
-ACTION_RETURN_TYPE UFMN(start_auth1)(FSM_TYPE_PTR pfsm)
+ACTION_RETURN_TYPE UFMN(act_start_auth1)(FSM_TYPE_PTR pfsm)
 {
 	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return THIS(noEvent);
 }
 
-ACTION_RETURN_TYPE UFMN(start_auth2)(FSM_TYPE_PTR pfsm)
+ACTION_RETURN_TYPE UFMN(act_start_auth2)(FSM_TYPE_PTR pfsm)
 {
 	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
@@ -19,6 +19,13 @@ ACTION_RETURN_TYPE UFMN(start_data_sync)(FSM_TYPE_PTR pfsm)
 	DBG_PRINTF("%s", __func__);
 	(void) pfsm;
 	return THIS(noEvent);
+}
+
+ACTION_RETURN_TYPE UFMN(report_done)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+	(void) pfsm;
+	return PARENT(peer_data_synced);
 }
 
 ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)

--- a/test/full_test154/first_connection.fsms
+++ b/test/full_test154/first_connection.fsms
@@ -27,6 +27,13 @@ native impl
 	event parent::auth1_complete;
 	event parent::auth2_complete;
 	event parent::peer_data_synced;
+	event parent::start_auth1;
+	event parent::auth1_gatt;
+	event parent::start_auth2;
+	event parent::auth2_gatt;
+	event parent::start_sync;
+	event parent::sync_gatt;
+	event parent::comm_window_timer_expired;
 
 	state initial;
 	state waiting;
@@ -37,9 +44,19 @@ native impl
 
 	transition              [activate, initial] waiting;
 
-	action start_auth1      [peer_connected, waiting] transition auth1;
-	action start_auth2      [auth1_complete, auth1] transition auth2;
-	action start_data_sync  [auth2_complete, auth2] transition data_sync;
-	transition              [peer_data_synced, data_sync] done;
+	action act_start_auth1  [peer_connected, waiting]     transition auth1;
+	action act_start_auth2  [auth1_complete, auth1]       transition auth2;
+	action start_data_sync  [auth2_complete, auth2]       transition data_sync;
+	action report_done      [peer_data_synced, data_sync] transition done;
+
+	/* forward to peer sub-machines. */
+	action share_parent_start_auth1                 [start_auth1, (all)];
+	action share_parent_auth1_gatt                  [auth1_gatt, (all)];
+	action share_parent_start_auth2                 [start_auth2, (all)];
+	action share_parent_auth2_gatt                  [auth2_gatt, (all)];
+	action share_parent_start_sync                  [start_sync, (all)];
+	action share_parent_sync_gatt                   [sync_gatt, (all)];
+	action share_parent_comm_window_timer_expired   [comm_window_timer_expired, (all)];
+
 }
 

--- a/test/full_test154/sync-actions.c
+++ b/test/full_test154/sync-actions.c
@@ -1,0 +1,20 @@
+#include "sync_priv.h"
+
+ACTION_RETURN_TYPE UFMN(report_sync_complete)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+
+	(void) pfsm;
+
+	return PARENT(peer_data_synced);
+}
+
+ACTION_RETURN_TYPE UFMN(noAction)(FSM_TYPE_PTR pfsm)
+{
+	DBG_PRINTF("%s", __func__);
+
+	(void) pfsm;
+
+	return THIS(noEvent);
+}
+

--- a/test/full_test154/sync.fsms
+++ b/test/full_test154/sync.fsms
@@ -1,0 +1,25 @@
+/**
+	This machine handles the sync chores.
+*/
+machine sync
+native impl
+{
+#define FSM_ENTRY(A)
+#define FSM_EXIT(A) DBG_PRINTF("end state: %s", SYNC_STATE_NAMES[(A)->state])
+#define ACTION_ENTRY(A)
+#define ACTION_EXIT(A)
+}
+{
+	state initial;
+	state active;
+	state done;
+
+	event parent::activate;
+	event parent::start_sync;
+	event parent::sync_gatt;
+
+	transition [activate, (all)] active;
+	action report_sync_complete[sync_gatt, active] transition done;
+
+}
+

--- a/test/full_test154/test.c
+++ b/test/full_test154/test.c
@@ -44,13 +44,19 @@ static void scan_happy_path()
 	e.event_data.ble_comm_data.ble_e.type = ble_adv_packet;
 	run_communicator_instance0(&e);
 
-	e.event = THIS(auth1_complete);
+	e.event = THIS(ble_comm);
+	e.event_data.ble_comm_data.ble_e.type = ble_gatt_message;
+	e.event_data.ble_comm_data.ble_e.data.gatt_msg.characteristic = AUTH1_GATT;
 	run_communicator_instance0(&e);
 
-	e.event = THIS(auth2_complete);
+	e.event = THIS(ble_comm);
+	e.event_data.ble_comm_data.ble_e.type = ble_gatt_message;
+	e.event_data.ble_comm_data.ble_e.data.gatt_msg.characteristic = AUTH2_GATT;
 	run_communicator_instance0(&e);
 
-	e.event = THIS(peer_data_synced);
+	e.event = THIS(ble_comm);
+	e.event_data.ble_comm_data.ble_e.type = ble_gatt_message;
+	e.event_data.ble_comm_data.ble_e.data.gatt_msg.characteristic = SYNC_GATT;
 	run_communicator_instance0(&e);
 
 }
@@ -91,6 +97,24 @@ static void connect_happy_path()
 	e.event_data.command_data.command.tag = command_peer_comm_period;
 	e.event_data.command_data.command.data.peer_comm_period = 0;
 	run_communicator_instance1(&e);
+
+	e.event = THIS(comm_window_timer_expired);
+	run_communicator_instance1(&e);
+
+	e.event = THIS(ble_comm);
+	e.event_data.ble_comm_data.ble_e.type = ble_gatt_message;
+	e.event_data.ble_comm_data.ble_e.data.gatt_msg.characteristic = AUTH1_GATT;
+	run_communicator_instance0(&e);
+
+	e.event = THIS(ble_comm);
+	e.event_data.ble_comm_data.ble_e.type = ble_gatt_message;
+	e.event_data.ble_comm_data.ble_e.data.gatt_msg.characteristic = AUTH2_GATT;
+	run_communicator_instance0(&e);
+
+	e.event = THIS(ble_comm);
+	e.event_data.ble_comm_data.ble_e.type = ble_gatt_message;
+	e.event_data.ble_comm_data.ble_e.data.gatt_msg.characteristic = SYNC_GATT;
+	run_communicator_instance0(&e);
 
 }
 

--- a/test/full_test154/test.canonical
+++ b/test/full_test154/test.canonical
@@ -10,6 +10,15 @@ event: communicator_ble_activate; state: communicator_ble_initial
 communicator_ble_noAction
 communicator_ble_set_defaults
 end state: communicator_ble_waiting
+event: communicator_auth1_activate; state: communicator_auth1_initial
+communicator_auth1_noAction
+end state: communicator_auth1_active
+event: communicator_auth2_activate; state: communicator_auth2_initial
+communicator_auth2_noAction
+end state: communicator_auth2_active
+event: communicator_sync_activate; state: communicator_sync_initial
+communicator_sync_noAction
+end state: communicator_sync_active
 communicator_set_defaults
 end state: communicator_waiting
 communicator_grab_command
@@ -59,21 +68,55 @@ communicator_ble_set_defaults
 end state: communicator_ble_waiting
 event: communicator_peer_connected; state: communicator_first_time_connect
 event: communicator_peer_connected; state: communicator_first_connection_waiting
-communicator_first_connection_start_auth1
+communicator_first_connection_act_start_auth1
 end state: communicator_first_connection_auth1
 end state: communicator_first_time_connect
-event: communicator_auth1_complete; state: communicator_first_time_connect
+communicator_grab_ble_comm
+communicator_ble_translate_ble_comm
+event: communicator_ble_gatt_msg; state: communicator_ble_waiting
+communicator_ble_report_gatt_characteristic
+end state: communicator_ble_waiting
+event: communicator_auth1_gatt; state: communicator_first_time_connect
+event: communicator_auth1_gatt; state: communicator_first_connection_auth1
+communicator_first_connection_share_parent_auth1_gatt
+event: communicator_auth1_auth1_gatt; state: communicator_auth1_active
+communicator_auth1_report_auth1_complete
+end state: communicator_auth1_done
 event: communicator_auth1_complete; state: communicator_first_connection_auth1
-communicator_first_connection_start_auth2
+communicator_first_connection_act_start_auth2
 end state: communicator_first_connection_auth2
 end state: communicator_first_time_connect
-event: communicator_auth2_complete; state: communicator_first_time_connect
+communicator_grab_ble_comm
+communicator_ble_translate_ble_comm
+event: communicator_ble_gatt_msg; state: communicator_ble_waiting
+communicator_ble_report_gatt_characteristic
+end state: communicator_ble_waiting
+event: communicator_auth2_gatt; state: communicator_first_time_connect
+event: communicator_auth2_gatt; state: communicator_first_connection_auth2
+communicator_first_connection_share_parent_auth2_gatt
+event: communicator_auth2_auth2_gatt; state: communicator_auth2_active
+communicator_auth2_report_auth2_complete
+end state: communicator_auth2_done
 event: communicator_auth2_complete; state: communicator_first_connection_auth2
 communicator_first_connection_start_data_sync
 end state: communicator_first_connection_data_sync
 end state: communicator_first_time_connect
-event: communicator_peer_data_synced; state: communicator_first_time_connect
+communicator_grab_ble_comm
+communicator_ble_translate_ble_comm
+event: communicator_ble_gatt_msg; state: communicator_ble_waiting
+communicator_ble_report_gatt_characteristic
+end state: communicator_ble_waiting
+event: communicator_sync_gatt; state: communicator_first_time_connect
+event: communicator_sync_gatt; state: communicator_first_connection_data_sync
+communicator_first_connection_share_parent_sync_gatt
+event: communicator_sync_sync_gatt; state: communicator_sync_active
+communicator_sync_report_sync_complete
+end state: communicator_sync_done
 event: communicator_peer_data_synced; state: communicator_first_connection_data_sync
+communicator_first_connection_report_done
+end state: communicator_first_connection_done
+event: communicator_peer_data_synced; state: communicator_first_time_connect
+event: communicator_peer_data_synced; state: communicator_first_connection_done
 communicator_first_connection_noAction
 end state: communicator_first_connection_done
 end state: communicator_connected_to_peer
@@ -89,6 +132,15 @@ event: communicator_ble_activate; state: communicator_ble_initial
 communicator_ble_noAction
 communicator_ble_set_defaults
 end state: communicator_ble_waiting
+event: communicator_auth1_activate; state: communicator_auth1_initial
+communicator_auth1_noAction
+end state: communicator_auth1_active
+event: communicator_auth2_activate; state: communicator_auth2_initial
+communicator_auth2_noAction
+end state: communicator_auth2_active
+event: communicator_sync_activate; state: communicator_sync_initial
+communicator_sync_noAction
+end state: communicator_sync_active
 communicator_set_defaults
 end state: communicator_waiting
 communicator_grab_command
@@ -166,6 +218,44 @@ event: communicator_first_connection_activate; state: communicator_first_connect
 communicator_first_connection_noAction
 end state: communicator_first_connection_waiting
 end state: communicator_first_time_connect
+event: communicator_comm_window_timer_expired; state: communicator_first_time_connect
+event: communicator_comm_window_timer_expired; state: communicator_first_connection_waiting
+communicator_first_connection_share_parent_comm_window_timer_expired
+event: communicator_ble_comm_window_timer_expired; state: communicator_ble_waiting_for_connection_window
+communicator_ble_look_for_peer
+event: communicator_ble_connection; state: communicator_ble_waiting_for_connection_window
+communicator_ble_report_connection
+communicator_ble_stop_connection_timer
+communicator_ble_set_defaults
+end state: communicator_ble_waiting
+event: communicator_peer_connected; state: communicator_first_connection_waiting
+communicator_first_connection_act_start_auth1
+end state: communicator_first_connection_auth1
+end state: communicator_first_time_connect
+communicator_grab_ble_comm
+communicator_ble_translate_ble_comm
+event: communicator_ble_gatt_msg; state: communicator_ble_waiting
+communicator_ble_report_gatt_characteristic
+end state: communicator_ble_waiting
+event: communicator_auth1_gatt; state: communicator_connected_to_peer
+communicator_noAction
+end state: communicator_connected_to_peer
+communicator_grab_ble_comm
+communicator_ble_translate_ble_comm
+event: communicator_ble_gatt_msg; state: communicator_ble_waiting
+communicator_ble_report_gatt_characteristic
+end state: communicator_ble_waiting
+event: communicator_auth2_gatt; state: communicator_connected_to_peer
+communicator_noAction
+end state: communicator_connected_to_peer
+communicator_grab_ble_comm
+communicator_ble_translate_ble_comm
+event: communicator_ble_gatt_msg; state: communicator_ble_waiting
+communicator_ble_report_gatt_characteristic
+end state: communicator_ble_waiting
+event: communicator_sync_gatt; state: communicator_connected_to_peer
+communicator_noAction
+end state: communicator_connected_to_peer
 
 test: force_find_and_run
 event: communicator_first_connection_activate; state: communicator_initial

--- a/test/full_test154/test_fsm.fsm
+++ b/test/full_test154/test_fsm.fsm
@@ -43,10 +43,17 @@ data
 
 	event ble_comm data translator grab_ble_comm implemented by machine ble {ble_event_str ble_e;};
 
+	event comm_window_timer_expired;
+
 	event peer_connected;
 	event start_auth1;
+	event auth1_gatt;
 	event auth1_complete;
+	event start_auth2;
+	event auth2_gatt;
 	event auth2_complete;
+	event start_sync;
+	event sync_gatt;
 	event peer_data_synced;
 
 	state initial;
@@ -64,12 +71,14 @@ data
 	include commands.fsms
 	include ble.fsms
 	include first_connection.fsms
+	include auth1.fsms
+	include auth2.fsms
+	include sync.fsms
 
 	action activate_all     [activate, (all)]                 transition waiting;
 	action start_looking    [configuration_complete, waiting] transition first_time_connect;
 
 	transition [peer_data_synced, first_time_connect] connected_to_peer;
-
 
 }
 

--- a/test/html/test1/test6.html.canonical
+++ b/test/html/test1/test6.html.canonical
@@ -224,7 +224,7 @@ code {
 		<tr><th>Number of events</th><td>2</td></tr>
 		<tr><th>Events not handled</th><td>0</td></tr>
 		<tr><th>Events handled in one state</th><td>2</td></tr>
-		<tr><th>At least one event handled the same in all states?</th><td>yes</td></tr>
+		<tr><th>At least one event handled the same in all states?</th><td>no</td></tr>
 		<tr><th>Number of states</th><td>2</td></tr>
 		<tr><th>Number of states with entry functions</th><td>1</td></tr>
 		<tr><th>Number of states with exit functions</th><td>1</td></tr>

--- a/test/unit/misc_cl_options/Makefile
+++ b/test/unit/misc_cl_options/Makefile
@@ -84,16 +84,16 @@ FSM=$(OUTPUT_DIR)/fsm
 all: test_file_listers test_file_creators test_file_failers clean
 
 test_file_failers: $(FAILERS)
-	@rm -f *.result
-	@rm -f fsmout
+	-@rm -f *.result
+	-@rm -f fsmout
 
 test_file_creators: $(CREATORS)
-	@rm $?
-	@rm -f *.result
+	-@rm $?
+	-@rm -f *.result
 
 test_file_listers: $(LISTERS)
-	@rm -f *.out
-	@rm -f *.result
+	-@rm -f *.out
+	-@rm -f *.result
 
 $(LISTERS): $(FSM) Makefile
 	$(FSM) $(FSM_FLAGS) test.fsm > $@.out
@@ -108,7 +108,7 @@ $(FAILERS): $(FSM) Makefile expectFailure.mk
 	@$(DIFF) fsmout $@.canonical
 
 clean::
-	@rm -f *.out        2> /dev/null
-	@rm -f *.result     2> /dev/null
+	-@rm -f *.out        2> /dev/null
+	-@rm -f *.result     2> /dev/null
 	-@rm -f $(CREATORS) 2> /dev/null
 


### PR DESCRIPTION
closes #332 

As now indicated in the bug report, the correct way to handle event forwarding is to fully embrace the idea that the sub-machine implements the state.  This leads to the conclusion that event forwarding is handled exactly as it always is - the machine decides when shared events will be shared.  The enabling thing is for the parent to provide the needed sharing functions.

Additionally, to make full_test153 pass, instance macros were adjusted to accommodate the need for the state implementing machines to have access to their parent.

The state- and translator-implementing machines are still supported only in Switch machine generation, even though some other C generator files have been updated.  The same applies to machines with actions returning void or states; though some changes have been made in those generators, even in the C Switch machine, only the case of actions returning events is currently supported.